### PR TITLE
fix: scroll stack layout fixes + My Story scrollable text

### DIFF
--- a/docs/plans/2026-02-25-scroll-stack-layout-design.md
+++ b/docs/plans/2026-02-25-scroll-stack-layout-design.md
@@ -1,0 +1,39 @@
+# Scroll Stack Layout — Design Doc
+**Date:** 2026-02-25
+
+## Problem
+
+Two layout issues introduced after the stacking scroll panel effect was applied:
+
+1. **`index.html` hero** — bento grid cards overflow the viewport height; full hero is not visible within the first stack panel.
+2. **`experience.html`** — the sticky experience wrapper is taller than the viewport, causing the Certifications section to slide over and obscure content the user hasn't scrolled to yet.
+
+## Decisions
+
+### `experience.html` — Option A: Un-stick experience, make Certifications the arriving card
+
+- Remove `sticky top-0 z-10` from the experience wrapper div → becomes `relative z-10`
+- Make `#certifications` a `stack-panel` with `--panel-z:20`
+- Add the same stack-panel CSS + scroll JS already used on `index.html` and `portfolio.html`
+- **Result**: user scrolls freely through all experience content; Certifications slides up as a card at the end
+
+### `index.html` hero — Option B: Restructure into 2-row asymmetric bento
+
+**Row 1** (`lg:col-span-2` + sidebar):
+- Intro card: name, title, 2-line description, slim audio + AI match strip
+- Sidebar card: location, open-to-work status, LinkedIn link, Download CV link
+
+**Row 2** (3 equal columns):
+- Portfolio card — icon, title, one-liner, arrow
+- Experience card — icon, title, one-liner, arrow
+- Download CV card — icon, title, one-liner, arrow
+
+**Constraints:**
+- Outer grid uses `h-screen py-16` to enforce viewport fit
+- Remove standalone "Let's Connect" contact card from grid (LinkedIn stays in sidebar)
+- Audio + AI match become a 2-column inline strip inside intro card (no individual card wrappers)
+
+## Out of Scope
+
+- No changes to `portfolio.html`
+- No changes to the modal/article system or JS routing

--- a/docs/plans/2026-02-25-scroll-stack-layout.md
+++ b/docs/plans/2026-02-25-scroll-stack-layout.md
@@ -1,0 +1,325 @@
+# Scroll Stack Layout Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the two layout issues introduced by the stacking scroll panels: hero cards overflowing the viewport on `index.html`, and experience content being obscured by early certifications overlap on `experience.html`.
+
+**Architecture:** Two independent file edits. `experience.html` — un-stick the experience wrapper, promote certifications to a stack-panel. `index.html` — replace the hero bento grid with a compact 2-row asymmetric layout that fits within `h-screen`.
+
+**Tech Stack:** Static HTML + Tailwind CSS CDN + inline `<style>` + vanilla JS. CRLF line endings on `index.html` (use Python `open(path,'rb')` for replacements). LF on `experience.html` (Edit tool works).
+
+---
+
+## Task 1: Fix `experience.html` — un-stick experience, promote certifications
+
+**Files:**
+- Modify: `experience.html` (LF line endings — Edit tool works)
+
+### Step 1: Add stack-panel CSS to `<style>` block
+
+Find the closing `</style>` tag (line ~117). Replace:
+
+```
+        .card-hover:hover {
+            transform: translateY(-4px);
+            background-color: rgba(255, 255, 255, 0.08);
+        }
+    </style>
+```
+
+With:
+
+```
+        .card-hover:hover {
+            transform: translateY(-4px);
+            background-color: rgba(255, 255, 255, 0.08);
+        }
+
+        /* ── Geist-style stacking scroll panels ── */
+        .stack-panel {
+            position: sticky;
+            top: 0;
+            z-index: var(--panel-z, 10);
+            background: #101c22;
+            transform-origin: top center;
+            transition: scale 0.55s cubic-bezier(0.4,0,0.2,1),
+                        filter 0.55s cubic-bezier(0.4,0,0.2,1),
+                        border-radius 0.55s cubic-bezier(0.4,0,0.2,1);
+            will-change: scale, filter;
+        }
+        .stack-panel + .stack-panel {
+            border-radius: 1.5rem 1.5rem 0 0;
+            box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.55);
+        }
+        .stack-panel.is-covered {
+            scale: 0.965;
+            filter: brightness(0.58);
+            border-radius: 1.5rem;
+        }
+    </style>
+```
+
+### Step 2: Un-stick the experience wrapper div
+
+Find (line ~169):
+```
+            <div class="sticky top-0 z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
+```
+
+Replace with:
+```
+            <div class="relative z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
+```
+
+### Step 3: Make certifications a stack-panel
+
+Find (line ~437):
+```
+            <section id="certifications" class="relative z-20 w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24">
+```
+
+Replace with:
+```
+            <section id="certifications" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
+```
+
+### Step 4: Add scroll JS before closing `</script>` tag
+
+Find (line ~750):
+```
+    <script>
+        function toggleMenu() {
+            const menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('translate-x-full');
+        }
+    </script>
+```
+
+Replace with:
+```
+    <script>
+        function toggleMenu() {
+            const menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('translate-x-full');
+        }
+    </script>
+    <script>
+        (function () {
+            var panels = document.querySelectorAll('.stack-panel');
+            if (!panels.length) return;
+            function update() {
+                var vh = window.innerHeight;
+                panels.forEach(function (panel, i) {
+                    var next = panels[i + 1];
+                    if (!next) return;
+                    var nextTop = next.getBoundingClientRect().top;
+                    panel.classList.toggle('is-covered', nextTop < vh * 0.88);
+                });
+            }
+            window.addEventListener('scroll', update, { passive: true });
+            update();
+        })();
+    </script>
+```
+
+### Step 5: Verify in browser
+
+Open `experience.html`. Scroll through — all job cards and skills should be fully visible. When certifications enters view, it should slide up as a rounded card over the experience content.
+
+### Step 6: Commit
+
+```bash
+git add experience.html
+git commit -m "fix: un-stick experience section, certifications slides over as card"
+```
+
+---
+
+## Task 2: Restructure `index.html` hero into 2-row bento
+
+**Files:**
+- Modify: `index.html` (CRLF line endings — use Python `open(path,'rb')` for all replacements)
+
+### Step 1: Replace the entire hero section via Python
+
+The hero section is bounded by `<!-- Hero Section (Bento Grid Style) -->` and ends at the `</section>` immediately before `<!-- Testimonials Section -->`.
+
+Use Python to replace the entire block. The new hero HTML:
+
+```python
+NEW_HERO = '''<!-- Hero Section (Bento Grid Style) -->
+      <section class="stack-panel w-full h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8" style="--panel-z:10">
+        <div class="w-full max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-4 animate-fade-in py-16 h-full" style="grid-template-rows: 1fr auto;">
+
+          <!-- Row 1 Col 1-2: Main Intro Card -->
+          <div class="lg:col-span-2 flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-6 sm:p-8 relative overflow-hidden group">
+            <div class="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
+              <span class="material-symbols-outlined text-8xl text-primary">rocket_launch</span>
+            </div>
+            <div class="flex flex-col gap-3">
+              <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tighter text-white">Matthew <br>Thaokhamlue</h1>
+              <p class="text-lg text-primary font-medium tracking-tight">Senior Product Manager</p>
+              <p class="text-white/60 max-w-xl leading-relaxed">Crafting high-impact products at the intersection of technology and user-centric design. Specializing in AI/ML, SaaS, and platform development.</p>
+            </div>
+            <!-- Slim Audio + AI Match strip -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-white/5 border border-white/5">
+                <span class="material-symbols-outlined text-primary text-sm shrink-0">graphic_eq</span>
+                <audio controls class="w-full h-7 opacity-80 hover:opacity-100 transition-opacity"
+                  onplay="if(typeof gtag===\'function\'){gtag(\'event\',\'audio_played\',{audio_title:\'role_discussion\',action:\'play\'})}"
+                  onpause="if(typeof gtag===\'function\'){gtag(\'event\',\'audio_played\',{audio_title:\'role_discussion\',action:\'pause\'})}">
+                  <source src="Podcast about Matthew Thaokhamlue\'s Technical Product Manager role.wav" type="audio/wav" />
+                </audio>
+              </div>
+              <button id="ai-match-trigger" type="button"
+                class="flex items-center gap-3 px-4 py-3 rounded-xl border border-primary/35 bg-primary/10 hover:bg-primary/20 transition-colors text-left">
+                <span class="material-symbols-outlined text-primary text-sm shrink-0">smart_toy</span>
+                <span class="text-sm font-semibold text-white">Evaluate role fit</span>
+              </button>
+            </div>
+          </div>
+
+          <!-- Row 1 Col 3: Availability Sidebar -->
+          <div class="flex flex-col gap-3 rounded-2xl bg-surface border border-white/5 p-6">
+            <div class="flex items-center gap-3">
+              <span class="material-symbols-outlined text-primary">location_on</span>
+              <div>
+                <p class="text-white font-medium text-sm">Berlin, Germany</p>
+                <p class="text-white/50 text-xs">Open to opportunities</p>
+              </div>
+            </div>
+            <div class="h-px bg-white/5"></div>
+            <a href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
+              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
+              onclick="if(typeof gtag===\'function\'){gtag(\'event\',\'external_link_clicked\',{destination_platform:\'linkedin\',link_type:\'sidebar\',location:\'hero_sidebar\'})}">
+              <i class="fab fa-linkedin text-lg text-primary shrink-0"></i>
+              <span class="text-white/70 group-hover:text-white text-sm transition-colors">LinkedIn</span>
+              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
+            </a>
+            <a href="https://github.com/matthew-thaokhamlue" target="_blank"
+              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
+              onclick="if(typeof gtag===\'function\'){gtag(\'event\',\'external_link_clicked\',{destination_platform:\'github\',link_type:\'sidebar\',location:\'hero_sidebar\'})}">
+              <i class="fab fa-github text-lg text-white/60 shrink-0"></i>
+              <span class="text-white/70 group-hover:text-white text-sm transition-colors">GitHub</span>
+              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
+            </a>
+            <div class="h-px bg-white/5"></div>
+            <a href="Matthew main CV.pdf" target="_blank" rel="noopener noreferrer"
+              class="flex items-center justify-center gap-2 mt-auto h-10 px-4 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-xl transition-colors shadow-lg shadow-primary/20"
+              onclick="if(typeof gtag===\'function\'){gtag(\'event\',\'resume_downloaded\',{file_name:\'Matthew main CV.pdf\',page_location:\'index\'})}">
+              <span class="material-symbols-outlined text-sm">download</span>
+              Download CV
+            </a>
+          </div>
+
+          <!-- Row 2: 3 compact action cards -->
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
+            href="portfolio.html">
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">grid_view</span>
+              </div>
+              <div>
+                <h3 class="font-bold text-white">Portfolio</h3>
+                <p class="text-white/50 text-sm">Explore my work</p>
+              </div>
+            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+          </a>
+
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
+            href="experience.html">
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">description</span>
+              </div>
+              <div>
+                <h3 class="font-bold text-white">Experience</h3>
+                <p class="text-white/50 text-sm">Skills &amp; certifications</p>
+              </div>
+            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+          </a>
+
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-primary/10 border border-primary/20 p-5 transition-all duration-300 hover:bg-primary/20 hover:-translate-y-1"
+            href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
+            onclick="if(typeof gtag===\'function\'){gtag(\'event\',\'external_link_clicked\',{destination_platform:\'linkedin\',link_type:\'cta_button\',location:\'hero_section\'})}">
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">person_add</span>
+              </div>
+              <div>
+                <h3 class="font-bold text-white">Let\'s Connect</h3>
+                <p class="text-white/50 text-sm">Get in touch</p>
+              </div>
+            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+          </a>
+
+        </div>
+      </section>'''
+```
+
+Run the replacement via Python:
+
+```python
+with open('index.html', 'rb') as f:
+    raw = f.read()
+html = raw.decode('utf-8')
+
+# Find old hero block
+start_marker = '<!-- Hero Section (Bento Grid Style) -->'
+end_marker = '\r\n\r\n      <!-- Testimonials Section -->'
+
+start_idx = html.find(start_marker)
+end_idx = html.find(end_marker)
+assert start_idx != -1 and end_idx != -1
+
+# Find the </section> that closes the hero (just before end_marker)
+close_tag = '</section>'
+close_idx = html.rfind(close_tag, start_idx, end_idx)
+assert close_idx != -1
+end_of_hero = close_idx + len(close_tag)
+
+html = html[:start_idx] + NEW_HERO + html[end_of_hero:]
+
+out = html.replace('\r\n', '\n').replace('\n', '\r\n')
+with open('index.html', 'wb') as f:
+    f.write(out.encode('utf-8'))
+```
+
+### Step 2: Verify in browser
+
+Open `index.html`. Check:
+- All hero content visible without scrolling on a standard 1280×800 desktop viewport
+- Row 1: intro card (left 2/3) + sidebar card (right 1/3)
+- Row 2: Portfolio / Experience / Let's Connect action cards
+- Audio player and AI match button visible in the slim strip
+- No overflow or clipping
+
+Mobile check: on a narrow viewport the grid should collapse to single column cleanly.
+
+### Step 3: Commit
+
+```bash
+git add index.html
+git commit -m "fix: restructure hero bento into 2-row layout to fit viewport"
+```
+
+---
+
+## Task 3: Final verification pass
+
+Open both pages side by side:
+
+1. `index.html` — hero fits in viewport, scroll → testimonials slides over → my story slides over
+2. `experience.html` — scroll through all jobs + skills freely, certifications slides up as a card at the end
+
+If anything overflows on mobile (viewport < 768px), reduce `text-4xl` to `text-3xl` on the hero heading and `p-6` to `p-4` on the intro card.
+
+### Commit (if any tweaks made)
+
+```bash
+git add index.html experience.html
+git commit -m "fix: mobile tweaks for hero and experience stack panels"
+```

--- a/experience.html
+++ b/experience.html
@@ -114,6 +114,28 @@
             transform: translateY(-4px);
             background-color: rgba(255, 255, 255, 0.08);
         }
+
+        /* ── Geist-style stacking scroll panels ── */
+        .stack-panel {
+            position: sticky;
+            top: 0;
+            z-index: var(--panel-z, 10);
+            background: #101c22;
+            transform-origin: top center;
+            transition: scale 0.55s cubic-bezier(0.4,0,0.2,1),
+                        filter 0.55s cubic-bezier(0.4,0,0.2,1),
+                        border-radius 0.55s cubic-bezier(0.4,0,0.2,1);
+            will-change: scale, filter;
+        }
+        .stack-panel + .stack-panel {
+            border-radius: 1.5rem 1.5rem 0 0;
+            box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.55);
+        }
+        .stack-panel.is-covered {
+            scale: 0.965;
+            filter: brightness(0.58);
+            border-radius: 1.5rem;
+        }
     </style>
 </head>
 
@@ -166,7 +188,7 @@
         <main class="relative z-10 flex flex-1 flex-col">
 
             <!-- Sticky Experience Section -->
-            <div class="sticky top-0 z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
+            <div class="relative z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
 
                 <!-- Header -->
                 <div
@@ -434,7 +456,7 @@
             </div><!-- /sticky experience -->
 
             <!-- Certifications Scroll-Over Section -->
-            <section id="certifications" class="relative z-20 w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24">
+            <section id="certifications" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
                 <div class="max-w-7xl mx-auto flex flex-col gap-12">
 
                     <!-- Section Header -->
@@ -747,6 +769,23 @@
             const menu = document.getElementById('mobile-menu');
             menu.classList.toggle('translate-x-full');
         }
+    </script>
+    <script>
+        (function () {
+            var panels = document.querySelectorAll('.stack-panel');
+            if (!panels.length) return;
+            function update() {
+                var vh = window.innerHeight;
+                panels.forEach(function (panel, i) {
+                    var next = panels[i + 1];
+                    if (!next) return;
+                    var nextTop = next.getBoundingClientRect().top;
+                    panel.classList.toggle('is-covered', nextTop < vh * 0.88);
+                });
+            }
+            window.addEventListener('scroll', update, { passive: true });
+            update();
+        })();
     </script>
 </body>
 

--- a/experience.html
+++ b/experience.html
@@ -16,17 +16,19 @@
     <title>Experience - Matthew Thaokhamlue</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
 
-  <meta name="description" content="Matthew Thaokhamlue's professional experience - Senior Product Manager at Labforward, Technical Product Manager at LabTwin, Product Owner at Thryve, Senior Risk Consultant at Ernst & Young. AI/ML, SaaS, health analytics expertise." />
-  <meta name="author" content="Matthew Thaokhamlue" />
-  <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://matthew-thaokhamlue.github.io/resume/experience.html" />
+    <meta name="description"
+        content="Matthew Thaokhamlue's professional experience - Senior Product Manager at Labforward, Technical Product Manager at LabTwin, Product Owner at Thryve, Senior Risk Consultant at Ernst & Young. AI/ML, SaaS, health analytics expertise." />
+    <meta name="author" content="Matthew Thaokhamlue" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://matthew-thaokhamlue.github.io/resume/experience.html" />
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="Experience - Matthew Thaokhamlue, Senior Product Manager" />
-  <meta property="og:description" content="7+ years of product management experience: Labforward (Senior PM), LabTwin (Technical PM), Thryve (Product Owner scaling to 1M+ users), Ernst & Young. AI/ML, B2B SaaS, health analytics." />
-  <meta property="og:type" content="profile" />
-  <meta property="og:url" content="https://matthew-thaokhamlue.github.io/resume/experience.html" />
-  <meta property="og:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Experience - Matthew Thaokhamlue, Senior Product Manager" />
+    <meta property="og:description"
+        content="7+ years of product management experience: Labforward (Senior PM), LabTwin (Technical PM), Thryve (Product Owner scaling to 1M+ users), Ernst & Young. AI/ML, B2B SaaS, health analytics." />
+    <meta property="og:type" content="profile" />
+    <meta property="og:url" content="https://matthew-thaokhamlue.github.io/resume/experience.html" />
+    <meta property="og:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
@@ -122,19 +124,27 @@
             z-index: var(--panel-z, 10);
             background: #101c22;
             transform-origin: top center;
-            transition: scale 0.55s cubic-bezier(0.4,0,0.2,1),
-                        filter 0.55s cubic-bezier(0.4,0,0.2,1),
-                        border-radius 0.55s cubic-bezier(0.4,0,0.2,1);
+            transition: scale 0.55s cubic-bezier(0.4, 0, 0.2, 1),
+                filter 0.55s cubic-bezier(0.4, 0, 0.2, 1),
+                border-radius 0.55s cubic-bezier(0.4, 0, 0.2, 1);
             will-change: scale, filter;
         }
-        .stack-panel + .stack-panel {
+
+        .stack-panel+.stack-panel {
             border-radius: 1.5rem 1.5rem 0 0;
             box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.55);
         }
+
         .stack-panel.is-covered {
             scale: 0.965;
             filter: brightness(0.58);
             border-radius: 1.5rem;
+        }
+
+        /* Direct card-arrival styles for single arriving panels */
+        .arriving-card {
+            border-radius: 1.5rem 1.5rem 0 0;
+            box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.55);
         }
     </style>
 </head>
@@ -188,7 +198,8 @@
         <main class="relative z-10 flex flex-1 flex-col">
 
             <!-- Sticky Experience Section -->
-            <div class="relative z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
+            <div
+                class="relative z-10 w-full flex flex-col items-center px-4 sm:px-6 lg:px-8 py-12 sm:py-16 md:py-20 gap-16 animate-fade-in">
 
                 <!-- Header -->
                 <div
@@ -221,7 +232,8 @@
                                 <span>Berlin, Germany</span>
                             </div>
                             <div class="mt-4">
-                                <a href="portfolio/labforward.html" class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
+                                <a href="portfolio/labforward.html"
+                                    class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
                                     <span>View Portfolio</span>
                                     <span class="material-symbols-outlined text-sm">arrow_forward</span>
                                 </a>
@@ -238,9 +250,11 @@
                                     into daily decisions.</li>
                             </ul>
                             <div class="flex flex-wrap gap-2 mt-2">
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Product
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Product
                                     Roadmap</span>
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Rapid
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Rapid
                                     Prototyping</span>
                                 <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">BI
                                     Automation</span>
@@ -263,7 +277,8 @@
                                 <span>Berlin, Germany</span>
                             </div>
                             <div class="mt-4">
-                                <a href="portfolio/labtwin.html" class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
+                                <a href="portfolio/labtwin.html"
+                                    class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
                                     <span>View Portfolio</span>
                                     <span class="material-symbols-outlined text-sm">arrow_forward</span>
                                 </a>
@@ -273,16 +288,18 @@
                             <ul class="space-y-3 text-white/70 list-disc list-outside ml-4">
                                 <li>Drove roadmap for voice and integration features supporting scientists in real lab
                                     environments.</li>
-                                <li>Led the effort to streamline release processes with engineering, tripling deployment frequency (<strong
-                                        class="text-white">4 → 12 per year</strong>).</li>
+                                <li>Led the effort to streamline release processes with engineering, tripling deployment
+                                    frequency (<strong class="text-white">4 → 12 per year</strong>).</li>
                                 <li>Spearheaded retraining strategies for speech recognition, keeping scientific term
                                     accuracy at <strong class="text-white">95%</strong>.</li>
                                 <li>Mentored a junior PM, encouraging autonomy and strong product intuition.</li>
                             </ul>
                             <div class="flex flex-wrap gap-2 mt-2">
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Voice
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Voice
                                     AI</span>
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Release
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Release
                                     Management</span>
                             </div>
                         </div>
@@ -303,7 +320,8 @@
                                 <span>Berlin, Germany</span>
                             </div>
                             <div class="mt-4">
-                                <a href="portfolio/thryve.html" class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
+                                <a href="portfolio/thryve.html"
+                                    class="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-lg transition-colors">
                                     <span>View Portfolio</span>
                                     <span class="material-symbols-outlined text-sm">arrow_forward</span>
                                 </a>
@@ -311,11 +329,14 @@
                         </div>
                         <div class="flex flex-col gap-4 md:w-2/3">
                             <ul class="space-y-3 text-white/70 list-disc list-outside ml-4">
-                                <li>Owned and scaled APIs and SDKs powering <strong class="text-white">1M+ users</strong>
+                                <li>Owned and scaled APIs and SDKs powering <strong class="text-white">1M+
+                                        users</strong>
                                     across 100+ B2B partners in digital health.</li>
-                                <li>Led 10+ wearable integrations (Fitbit, Garmin, Withings, Oura, Apple Health, and more).
+                                <li>Led 10+ wearable integrations (Fitbit, Garmin, Withings, Oura, Apple Health, and
+                                    more).
                                 </li>
-                                <li>Contributed to company growth from <strong class="text-white">€0 → €1M ARR</strong> and
+                                <li>Contributed to company growth from <strong class="text-white">€0 → €1M ARR</strong>
+                                    and
                                     from 7 → 35 people.</li>
                                 <li>Founded "Thryve Academy," a learning program that onboarded and aligned new hires in
                                     record time.</li>
@@ -323,7 +344,8 @@
                             <div class="flex flex-wrap gap-2 mt-2">
                                 <span
                                     class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">API/SDK</span>
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Wearable
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Wearable
                                     Integrations</span>
                             </div>
                         </div>
@@ -346,7 +368,8 @@
                         </div>
                         <div class="flex flex-col gap-4 md:w-2/3">
                             <ul class="space-y-3 text-white/70 list-disc list-outside ml-4">
-                                <li>Drove risk assessments and process improvement projects for Thailand's largest corps.
+                                <li>Drove risk assessments and process improvement projects for Thailand's largest
+                                    corps.
                                 </li>
                                 <li>Developed risk management frameworks and control testing procedures for digital
                                     transformation initiatives.</li>
@@ -356,7 +379,8 @@
                             <div class="flex flex-wrap gap-2 mt-2">
                                 <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Risk
                                     Management</span>
-                                <span class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Process
+                                <span
+                                    class="px-3 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">Process
                                     Improvement</span>
                             </div>
                         </div>
@@ -406,7 +430,8 @@
                             </h4>
                             <div class="flex flex-col gap-4">
                                 <div class="border-l-2 border-primary/30 pl-4">
-                                    <p class="font-bold text-white text-sm">Master of International and Development Economics</p>
+                                    <p class="font-bold text-white text-sm">Master of International and Development
+                                        Economics</p>
                                     <p class="text-primary text-xs mt-1">University of Applied Science Berlin</p>
                                     <p class="text-white/40 text-xs mt-1">DAAD Scholarship Recipient</p>
                                 </div>
@@ -456,7 +481,8 @@
             </div><!-- /sticky experience -->
 
             <!-- Certifications Scroll-Over Section -->
-            <section id="certifications" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
+            <section id="certifications"
+                class="stack-panel arriving-card w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
                 <div class="max-w-7xl mx-auto flex flex-col gap-12">
 
                     <!-- Section Header -->
@@ -479,10 +505,12 @@
 
                         <!-- Professional Scrum Product Owner I -->
                         <a href="https://www.scrum.org/certificates/508122"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'scrum.org',credential_name:'Professional Scrum Product Owner I'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'scrum.org',credential_name:'Professional Scrum Product Owner I'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">sprint</span>
                                 </div>
                                 <span
@@ -491,7 +519,9 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">Professional Scrum Product Owner I</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Scrum.org</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Supports backlog prioritization around customer value, clear acceptance criteria, and explicit trade-off communication when scope pressure increases.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Supports backlog prioritization around
+                                    customer value, clear acceptance criteria, and explicit trade-off communication when
+                                    scope pressure increases.</p>
                             </div>
                         </a>
 
@@ -501,16 +531,20 @@
                             target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">sync</span>
                                 </div>
                                 <span
                                     class="material-symbols-outlined text-white/20 group-hover:text-primary/30 transition-colors">open_in_new</span>
                             </div>
                             <div>
-                                <h3 class="text-xl font-bold text-white mb-2">PMI Agile Certified Practitioner (PMI-ACP)®</h3>
+                                <h3 class="text-xl font-bold text-white mb-2">PMI Agile Certified Practitioner
+                                    (PMI-ACP)®</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Project Management Institute</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Strengthens iterative delivery through smaller releases, faster feedback loops, and practical retrospectives that inform roadmap decisions.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Strengthens iterative delivery through
+                                    smaller releases, faster feedback loops, and practical retrospectives that inform
+                                    roadmap decisions.</p>
                             </div>
                         </a>
 
@@ -519,7 +553,8 @@
                             target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">draw</span>
                                 </div>
                                 <span
@@ -528,7 +563,9 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">Google UX Design Certificate</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Google via Coursera</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Improves product-design collaboration by grounding requirements in user flows, wireframes, and usability feedback before engineering implementation.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Improves product-design collaboration
+                                    by grounding requirements in user flows, wireframes, and usability feedback before
+                                    engineering implementation.</p>
                             </div>
                         </a>
 
@@ -538,16 +575,20 @@
                             target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">bar_chart</span>
                                 </div>
                                 <span
                                     class="material-symbols-outlined text-white/20 group-hover:text-primary/30 transition-colors">open_in_new</span>
                             </div>
                             <div>
-                                <h3 class="text-xl font-bold text-white mb-2">Google Business Intelligence Certificate</h3>
+                                <h3 class="text-xl font-bold text-white mb-2">Google Business Intelligence Certificate
+                                </h3>
                                 <p class="text-primary text-sm font-medium mb-3">Google</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Provides practical BI fundamentals to define meaningful metrics, interpret dashboards critically, and improve product review discussions.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Provides practical BI fundamentals to
+                                    define meaningful metrics, interpret dashboards critically, and improve product
+                                    review discussions.</p>
                             </div>
                         </a>
 
@@ -558,16 +599,20 @@
                             target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">architecture</span>
                                 </div>
                                 <span
                                     class="material-symbols-outlined text-white/20 group-hover:text-primary/30 transition-colors">open_in_new</span>
                             </div>
                             <div>
-                                <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure Solutions Architect Expert</h3>
+                                <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure Solutions Architect Expert
+                                </h3>
                                 <p class="text-primary text-sm font-medium mb-3">Microsoft</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Supports architecture discussions with engineering and clarifies cost, scalability, and reliability trade-offs in product decisions.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Supports architecture discussions with
+                                    engineering and clarifies cost, scalability, and reliability trade-offs in product
+                                    decisions.</p>
                             </div>
                         </a>
 
@@ -576,7 +621,8 @@
                             target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">smart_toy</span>
                                 </div>
                                 <span
@@ -585,34 +631,43 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure AI Engineer Associate</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Microsoft</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Builds understanding of AI system design, evaluation, and deployment constraints to scope GenAI features more realistically.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Builds understanding of AI system
+                                    design, evaluation, and deployment constraints to scope GenAI features more
+                                    realistically.</p>
                             </div>
                         </a>
 
                         <!-- Microsoft Azure Administrator Associate -->
                         <a href="https://www.credly.com/badges/7f8a7614-b5fd-4d2c-9c43-4a3b8368fb94/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">admin_panel_settings</span>
                                 </div>
                                 <span
                                     class="material-symbols-outlined text-white/20 group-hover:text-primary/30 transition-colors">open_in_new</span>
                             </div>
                             <div>
-                                <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure Administrator Associate</h3>
+                                <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure Administrator Associate
+                                </h3>
                                 <p class="text-primary text-sm font-medium mb-3">Microsoft</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Improves reasoning about cloud operations, permissions, and cost drivers when prioritizing platform and reliability work.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Improves reasoning about cloud
+                                    operations, permissions, and cost drivers when prioritizing platform and reliability
+                                    work.</p>
                             </div>
                         </a>
 
                         <!-- Microsoft Azure AI Fundamentals -->
                         <a href="https://www.credly.com/badges/45fb45cd-dc3d-4e35-80ce-d252dc3c4caa/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">psychology</span>
                                 </div>
                                 <span
@@ -621,16 +676,20 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure AI Fundamentals</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Microsoft</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Provides a practical baseline in AI and ML concepts, helping separate feasible use cases from vendor hype during discovery.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Provides a practical baseline in AI and
+                                    ML concepts, helping separate feasible use cases from vendor hype during discovery.
+                                </p>
                             </div>
                         </a>
 
                         <!-- Microsoft Azure Data Fundamentals -->
                         <a href="https://www.credly.com/badges/270ccc53-14f1-4169-9464-e6eadac533aa/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">storage</span>
                                 </div>
                                 <span
@@ -639,16 +698,20 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">Microsoft Azure Data Fundamentals</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Microsoft</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Improves framing of data requirements for analytics features, including data quality, storage choices, and reporting needs.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Improves framing of data requirements
+                                    for analytics features, including data quality, storage choices, and reporting
+                                    needs.</p>
                             </div>
                         </a>
 
                         <!-- AWS Solutions Architect Associate -->
                         <a href="https://www.credly.com/badges/68185585-2952-49bb-89c8-412ec2c6efff/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">cloud</span>
                                 </div>
                                 <span
@@ -657,16 +720,20 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">AWS Solutions Architect Associate</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Amazon Web Services</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Supports collaboration with engineering on AWS architecture options and clarifies product impact of security, latency, and cost decisions.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Supports collaboration with engineering
+                                    on AWS architecture options and clarifies product impact of security, latency, and
+                                    cost decisions.</p>
                             </div>
                         </a>
 
                         <!-- AWS SysOps Administrator -->
                         <a href="https://www.credly.com/badges/da129c0a-a6e5-4dc8-a463-beffb5e5e042/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">settings</span>
                                 </div>
                                 <span
@@ -675,16 +742,20 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">AWS SysOps Administrator Associate</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Amazon Web Services</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Improves understanding of monitoring and incident workflows to support clear communication, impact prioritization, and incident response.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Improves understanding of monitoring
+                                    and incident workflows to support clear communication, impact prioritization, and
+                                    incident response.</p>
                             </div>
                         </a>
 
                         <!-- AWS Cloud Practitioner -->
                         <a href="https://www.credly.com/badges/4cb5c446-2efc-4dc3-814c-7599c11cf732/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">cloud_done</span>
                                 </div>
                                 <span
@@ -693,35 +764,43 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">AWS Cloud Practitioner</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Amazon Web Services</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Builds baseline cloud vocabulary that improves communication with engineering and technical planning conversations.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Builds baseline cloud vocabulary that
+                                    improves communication with engineering and technical planning conversations.</p>
                             </div>
                         </a>
 
                         <!-- ========== CYBERSECURITY ========== -->
 
                         <!-- Google Cybersecurity Professional Certificate -->
-                        <a href="https://www.credly.com/badges/04d750a0-4b93-4bd7-8ea9-7ee6ec444a82/public_url" target="_blank"
+                        <a href="https://www.credly.com/badges/04d750a0-4b93-4bd7-8ea9-7ee6ec444a82/public_url"
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">shield</span>
                                 </div>
                                 <span
                                     class="material-symbols-outlined text-white/20 group-hover:text-primary/30 transition-colors">open_in_new</span>
                             </div>
                             <div>
-                                <h3 class="text-xl font-bold text-white mb-2">Google Cybersecurity Professional Certificate</h3>
+                                <h3 class="text-xl font-bold text-white mb-2">Google Cybersecurity Professional
+                                    Certificate</h3>
                                 <p class="text-primary text-sm font-medium mb-3">Google</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Reinforces secure-by-design thinking in product requirements, including threat awareness, access controls, and incident readiness.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Reinforces secure-by-design thinking in
+                                    product requirements, including threat awareness, access controls, and incident
+                                    readiness.</p>
                             </div>
                         </a>
 
                         <!-- CompTIA Security+ -->
                         <a href="https://www.credly.com/badges/4eb66bf5-6312-4eb9-b573-3a97d7106600/public_url"
-                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} " target="_blank"
+                            onclick="if(typeof gtag==='function'){gtag('event','credential_verified',{credential_issuer:'credly.com',credential_name:'credly.com certificate'})} "
+                            target="_blank"
                             class="group flex flex-col gap-4 p-6 rounded-2xl bg-surface border border-white/5 hover:bg-surface-hover hover:-translate-y-1 transition-all duration-300 hover:border-primary/30">
                             <div class="flex items-start justify-between">
-                                <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                                <div
+                                    class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary">
                                     <span class="material-symbols-outlined text-2xl">security</span>
                                 </div>
                                 <span
@@ -730,7 +809,9 @@
                             <div>
                                 <h3 class="text-xl font-bold text-white mb-2">CompTIA Security+ CE</h3>
                                 <p class="text-primary text-sm font-medium mb-3">CompTIA</p>
-                                <p class="text-white/60 text-sm leading-relaxed">Expands practical security foundations across risk, network security, and controls so security requirements are included earlier in planning.</p>
+                                <p class="text-white/60 text-sm leading-relaxed">Expands practical security foundations
+                                    across risk, network security, and controls so security requirements are included
+                                    earlier in planning.</p>
                             </div>
                         </a>
 
@@ -745,7 +826,8 @@
             <div
                 class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center gap-6">
                 <div class="flex flex-col gap-2 text-center md:text-left">
-                    <p class="text-white/60 text-sm">&copy; 2025 Matthew Thaokhamlue. All rights reserved.</p>
+                    <p class="text-white/60 text-sm">&copy; 2026 Matthew Thaokhamlue. All rights reserved.</p>
+                    <p class="text-white/40 text-xs">Product Manager | Berlin, Germany</p>
                 </div>
                 <div class="flex items-center gap-6">
                     <a href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"

--- a/index.html
+++ b/index.html
@@ -305,114 +305,114 @@
     <main class="relative z-10">
       <!-- Hero Section (Bento Grid Style) -->
       <section class="stack-panel w-full h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8" style="--panel-z:10">
-        <div class="w-full max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-4 animate-fade-in py-16 h-full" style="grid-template-rows: 1fr auto;">
-
-          <!-- Row 1 Col 1-2: Main Intro Card -->
-          <div class="lg:col-span-2 flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-6 sm:p-8 relative overflow-hidden group">
-            <div class="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
-              <span class="material-symbols-outlined text-8xl text-primary">rocket_launch</span>
-            </div>
-            <div class="flex flex-col gap-3">
-              <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tighter text-white">Matthew <br>Thaokhamlue</h1>
-              <p class="text-lg text-primary font-medium tracking-tight">Senior Product Manager</p>
-              <p class="text-white/60 max-w-xl leading-relaxed">Crafting high-impact products at the intersection of technology and user-centric design. Specializing in AI/ML, SaaS, and platform development.</p>
-            </div>
-            <!-- Slim Audio + AI Match strip -->
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-white/5 border border-white/5">
-                <span class="material-symbols-outlined text-primary text-sm shrink-0">graphic_eq</span>
-                <audio controls class="w-full h-7 opacity-80 hover:opacity-100 transition-opacity"
-                  onplay="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'play'})}"
-                  onpause="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'pause'})}">
-                  <source src="Podcast about Matthew Thaokhamlue's Technical Product Manager role.wav" type="audio/wav" />
-                </audio>
-              </div>
-              <button id="ai-match-trigger" type="button"
-                class="flex items-center gap-3 px-4 py-3 rounded-xl border border-primary/35 bg-primary/10 hover:bg-primary/20 transition-colors text-left">
-                <span class="material-symbols-outlined text-primary text-sm shrink-0">smart_toy</span>
-                <span class="text-sm font-semibold text-white">Evaluate role fit</span>
-              </button>
-            </div>
+        <div class="w-full max-w-7xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 animate-fade-in py-6 sm:py-8">
+        <!-- Main Intro Card -->
+        <div
+          class="lg:col-span-2 flex flex-col justify-center gap-3 rounded-2xl bg-surface border border-white/5 p-5 sm:p-6 relative overflow-hidden group">
+          <div class="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
+            <span class="material-symbols-outlined text-9xl text-primary">rocket_launch</span>
           </div>
+          <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tighter text-white">Matthew <br>Thaokhamlue
+          </h1>
+          <p class="text-base sm:text-lg text-primary font-medium tracking-tight">Senior Product Manager</p>
+          <p class="text-white/60 max-w-xl leading-relaxed">Crafting high-impact products at the intersection of
+            technology and user-centric design. Specializing in AI/ML, SaaS, and platform development.</p>
 
-          <!-- Row 1 Col 3: Availability Sidebar -->
-          <div class="flex flex-col gap-3 rounded-2xl bg-surface border border-white/5 p-6">
-            <div class="flex items-center gap-3">
-              <span class="material-symbols-outlined text-primary">location_on</span>
-              <div>
-                <p class="text-white font-medium text-sm">Berlin, Germany</p>
-                <p class="text-white/50 text-xs">Open to opportunities</p>
+          <!-- Audio + AI Match Actions -->
+          <div class="mt-2 grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div class="p-3 rounded-xl bg-white/5 border border-white/5 backdrop-blur-sm w-full h-full">
+              <div class="flex items-center gap-3 mb-2">
+                <div class="size-6 rounded-full bg-primary/20 flex items-center justify-center text-primary">
+                  <span class="material-symbols-outlined text-sm">graphic_eq</span>
+                </div>
+                <p class="text-xs font-medium text-white/80">Listen to my role discussion</p>
               </div>
+              <audio controls class="w-full h-8 opacity-80 hover:opacity-100 transition-opacity"
+                onplay="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'play'})}"
+                onpause="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'pause'})}">
+                <source src="Podcast about Matthew Thaokhamlue's Technical Product Manager role.wav" type="audio/wav" />
+                Your browser does not support the audio element.
+              </audio>
             </div>
-            <div class="h-px bg-white/5"></div>
-            <a href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
-              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
-              onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'sidebar',location:'hero_sidebar'})}">
-              <i class="fab fa-linkedin text-lg text-primary shrink-0"></i>
-              <span class="text-white/70 group-hover:text-white text-sm transition-colors">LinkedIn</span>
-              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
-            </a>
-            <a href="https://github.com/matthew-thaokhamlue" target="_blank"
-              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
-              onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'github',link_type:'sidebar',location:'hero_sidebar'})}">
-              <i class="fab fa-github text-lg text-white/60 shrink-0"></i>
-              <span class="text-white/70 group-hover:text-white text-sm transition-colors">GitHub</span>
-              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
-            </a>
-            <div class="h-px bg-white/5"></div>
-            <a href="Matthew main CV.pdf" target="_blank" rel="noopener noreferrer"
-              class="flex items-center justify-center gap-2 mt-auto h-10 px-4 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-xl transition-colors shadow-lg shadow-primary/20"
-              onclick="if(typeof gtag==='function'){gtag('event','resume_downloaded',{file_name:'Matthew main CV.pdf',page_location:'index'})}">
-              <span class="material-symbols-outlined text-sm">download</span>
-              Download CV
-            </a>
+            <button id="ai-match-trigger" type="button"
+              class="group w-full h-full p-3 rounded-xl border border-primary/35 bg-primary/10 hover:bg-primary/20 text-left transition-colors">
+              <span class="flex items-center gap-3">
+                <span class="material-symbols-outlined text-primary">smart_toy</span>
+                <span class="text-sm font-semibold text-white">Evaluate role fit with my evidence</span>
+              </span>
+            </button>
           </div>
-
-          <!-- Row 2: 3 compact action cards -->
-          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
-            href="portfolio.html">
-            <div class="flex items-center gap-4">
-              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
-                <span class="material-symbols-outlined">grid_view</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-white">Portfolio</h3>
-                <p class="text-white/50 text-sm">Explore my work</p>
-              </div>
-            </div>
-            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
-          </a>
-
-          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
-            href="experience.html">
-            <div class="flex items-center gap-4">
-              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
-                <span class="material-symbols-outlined">description</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-white">Experience</h3>
-                <p class="text-white/50 text-sm">Skills &amp; certifications</p>
-              </div>
-            </div>
-            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
-          </a>
-
-          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-primary/10 border border-primary/20 p-5 transition-all duration-300 hover:bg-primary/20 hover:-translate-y-1"
-            href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
-            onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'cta_button',location:'hero_section'})}">
-            <div class="flex items-center gap-4">
-              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
-                <span class="material-symbols-outlined">person_add</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-white">Let's Connect</h3>
-                <p class="text-white/50 text-sm">Get in touch</p>
-              </div>
-            </div>
-            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
-          </a>
-
         </div>
+
+        <!-- Right Column: Portfolio & Download CV Stacked -->
+        <div class="flex flex-col gap-4 h-full">
+          <!-- Portfolio Link Card -->
+          <a class="group flex flex-col justify-between gap-3 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30 flex-1"
+            href="portfolio.html">
+            <div>
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-2">
+                <span class="material-symbols-outlined text-xl">grid_view</span>
+              </div>
+              <h3 class="text-xl font-bold tracking-tight text-white">Matthew's Portfolio</h3>
+              <p class="text-white/60 mt-1 text-sm">Explore my work in leading cross-functional teams.</p>
+            </div>
+            <div class="flex items-center gap-2 text-primary font-medium mt-2">
+              <span class="text-sm">View Portfolio</span>
+              <span
+                class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+            </div>
+          </a>
+
+          <!-- Download CV Card -->
+          <a class="group flex flex-col justify-between gap-3 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30 flex-1"
+            href="Matthew main CV.pdf" target="_blank" rel="noopener noreferrer"
+            onclick="if(typeof gtag==='function'){gtag('event','resume_downloaded',{file_name:'Matthew main CV.pdf',page_location:'index'})}">
+            <div>
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-2">
+                <span class="material-symbols-outlined text-xl">download</span>
+              </div>
+              <h3 class="text-xl font-bold tracking-tight text-white">Download CV</h3>
+              <p class="text-white/60 mt-1 text-sm">Get a copy of my resume and detailed work history.</p>
+            </div>
+            <div class="flex items-center gap-2 text-primary font-medium mt-2">
+              <span class="text-sm">Download PDF</span>
+              <span
+                class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_downward</span>
+            </div>
+          </a>
+        </div>
+
+        <!-- Resume Link Card -->
+        <a class="group flex flex-col justify-between gap-3 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
+          href="experience.html">
+          <div>
+            <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-2">
+              <span class="material-symbols-outlined text-xl">description</span>
+            </div>
+            <h3 class="text-xl font-bold tracking-tight text-white">Experience & Skills</h3>
+            <p class="text-white/60 mt-1 text-sm">A detailed overview of my professional journey, skills, and certifications.</p>
+          </div>
+          <div class="flex items-center gap-2 text-primary font-medium mt-2">
+            <span class="text-sm">View Experience</span>
+            <span
+              class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+          </div>
+        </a>
+
+        <!-- Contact Card -->
+        <a class="group lg:col-span-2 flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-2xl bg-primary/10 border border-primary/20 p-5 transition-all duration-300 hover:bg-primary/20 hover:-translate-y-1"
+          href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
+          onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'cta_button',location:'hero_section'})}">
+          <div class="flex-1">
+            <h3 class="text-xl font-bold tracking-tight text-white">Let's Connect</h3>
+            <p class="text-white/70 mt-1 text-sm">Have a project in mind or want to talk about product? I'd love to hear from you.</p>
+          </div>
+          <button
+            class="flex shrink-0 items-center justify-center gap-2 h-10 px-5 bg-primary hover:bg-primary-dark text-white font-bold tracking-wide rounded-xl transition-colors shadow-lg shadow-primary/20">
+            <span class="text-sm">Get in Touch</span>
+            <span class="material-symbols-outlined text-sm">email</span>
+          </button>
+        </a>
       </section>
 
       <!-- Testimonials Section -->

--- a/index.html
+++ b/index.html
@@ -768,7 +768,7 @@
             </div>
 
             <!-- Story Text -->
-            <div class="md:w-[70%] flex flex-col gap-6 text-white/80 leading-relaxed text-lg">
+            <div class="md:w-[70%] flex flex-col gap-6 text-white/80 leading-relaxed text-lg overflow-y-auto max-h-[60vh] pr-4 custom-scrollbar">
               <p>
                 I still remember opening that letter. A DAAD scholarship to study in Berlin. I had to read it
                 three times to believe it was real. Me? Berlin? That moment taught me that taking a leap, even

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   </script>
   <meta charset="utf-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-  <title>Matthew Thaokhamlue - Technical Product Manager</title>
+  <title>Matthew Thaokhamlue - Product Manager</title>
   <meta name="description"
-    content="Technical Product Manager with 5+ years driving AI-powered innovation in health analytics and laboratory informatics B2B SaaS platforms." />
+    content="A Product Manager with 5+ years driving AI-powered innovation in health analytics and laboratory informatics B2B SaaS platforms." />
   <meta name="author" content="Matthew Thaokhamlue" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://matthew-thaokhamlue.github.io/resume/" />
@@ -178,14 +178,47 @@
 
     /* Testimonial marquee */
     @keyframes marquee {
-      0%   { transform: translateX(0); }
-      100% { transform: translateX(-50%); }
+      0% {
+        transform: translateX(0);
+      }
+
+      100% {
+        transform: translateX(-50%);
+      }
     }
+
     .marquee-track {
       animation: marquee 45s linear infinite;
     }
+
     .marquee-track:hover {
       animation-play-state: paused;
+    }
+
+    /* ── Geist-style stacking scroll panels ── */
+    .stack-panel {
+      position: sticky;
+      top: 0;
+      z-index: var(--panel-z, 10);
+      background: #101c22;
+      transform-origin: top center;
+      transition: scale 0.55s cubic-bezier(0.4,0,0.2,1),
+                  filter 0.55s cubic-bezier(0.4,0,0.2,1),
+                  border-radius 0.55s cubic-bezier(0.4,0,0.2,1);
+      will-change: scale, filter;
+    }
+
+    /* Incoming panels get a top-card edge */
+    .stack-panel + .stack-panel {
+      border-radius: 1.5rem 1.5rem 0 0;
+      box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.55);
+    }
+
+    /* Panel being covered: compress + dim */
+    .stack-panel.is-covered {
+      scale: 0.965;
+      filter: brightness(0.58);
+      border-radius: 1.5rem;
     }
   </style>
 </head>
@@ -269,415 +302,435 @@
       </button>
     </div>
 
-    <main
-      class="relative z-10 flex flex-1 flex-col">
+    <main class="relative z-10">
       <!-- Hero Section (Bento Grid Style) -->
-      <section class="sticky top-0 z-10 w-full min-h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8">
-        <div class="w-full max-w-7xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 animate-fade-in py-20 sm:py-24">
-        <!-- Main Intro Card -->
-        <div
-          class="lg:col-span-2 flex flex-col justify-center gap-6 rounded-2xl bg-surface border border-white/5 p-8 sm:p-10 relative overflow-hidden group">
-          <div class="absolute top-0 right-0 p-10 opacity-10 group-hover:opacity-20 transition-opacity">
-            <span class="material-symbols-outlined text-9xl text-primary">rocket_launch</span>
-          </div>
-          <h1 class="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tighter text-white">Matthew <br>Thaokhamlue
-          </h1>
-          <p class="text-lg sm:text-xl text-primary font-medium tracking-tight">Senior Product Manager</p>
-          <p class="text-white/60 max-w-xl text-lg leading-relaxed">Crafting high-impact products at the intersection of
-            technology and user-centric design. Specializing in AI/ML, SaaS, and platform development.</p>
+      <section class="stack-panel w-full h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8" style="--panel-z:10">
+        <div class="w-full max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-4 animate-fade-in py-16 h-full" style="grid-template-rows: 1fr auto;">
 
-          <!-- Audio + AI Match Actions -->
-          <div class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <div class="p-4 rounded-xl bg-white/5 border border-white/5 backdrop-blur-sm w-full h-full">
-              <div class="flex items-center gap-3 mb-2">
-                <div class="size-6 rounded-full bg-primary/20 flex items-center justify-center text-primary">
-                  <span class="material-symbols-outlined text-sm">graphic_eq</span>
-                </div>
-                <p class="text-xs font-medium text-white/80">Listen to my role discussion</p>
-              </div>
-              <audio controls class="w-full h-8 opacity-80 hover:opacity-100 transition-opacity"
-                onplay="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'play'})}"
-                onpause="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'pause'})}">
-                <source src="Podcast about Matthew Thaokhamlue's Technical Product Manager role.wav" type="audio/wav" />
-                Your browser does not support the audio element.
-              </audio>
+          <!-- Row 1 Col 1-2: Main Intro Card -->
+          <div class="lg:col-span-2 flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-6 sm:p-8 relative overflow-hidden group">
+            <div class="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
+              <span class="material-symbols-outlined text-8xl text-primary">rocket_launch</span>
             </div>
-            <button id="ai-match-trigger" type="button"
-              class="group w-full h-full p-4 rounded-xl border border-primary/35 bg-primary/10 hover:bg-primary/20 text-left transition-colors">
-              <span class="flex items-center gap-3">
-                <span class="material-symbols-outlined text-primary">smart_toy</span>
-                <span class="text-sm font-semibold text-white">Evaluate role fit with my evidence</span>
-              </span>
-            </button>
+            <div class="flex flex-col gap-3">
+              <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tighter text-white">Matthew <br>Thaokhamlue</h1>
+              <p class="text-lg text-primary font-medium tracking-tight">Senior Product Manager</p>
+              <p class="text-white/60 max-w-xl leading-relaxed">Crafting high-impact products at the intersection of technology and user-centric design. Specializing in AI/ML, SaaS, and platform development.</p>
+            </div>
+            <!-- Slim Audio + AI Match strip -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-white/5 border border-white/5">
+                <span class="material-symbols-outlined text-primary text-sm shrink-0">graphic_eq</span>
+                <audio controls class="w-full h-7 opacity-80 hover:opacity-100 transition-opacity"
+                  onplay="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'play'})}"
+                  onpause="if(typeof gtag==='function'){gtag('event','audio_played',{audio_title:'role_discussion',action:'pause'})}">
+                  <source src="Podcast about Matthew Thaokhamlue's Technical Product Manager role.wav" type="audio/wav" />
+                </audio>
+              </div>
+              <button id="ai-match-trigger" type="button"
+                class="flex items-center gap-3 px-4 py-3 rounded-xl border border-primary/35 bg-primary/10 hover:bg-primary/20 transition-colors text-left">
+                <span class="material-symbols-outlined text-primary text-sm shrink-0">smart_toy</span>
+                <span class="text-sm font-semibold text-white">Evaluate role fit</span>
+              </button>
+            </div>
           </div>
-        </div>
 
-        <!-- Right Column: Portfolio & Download CV Stacked -->
-        <div class="flex flex-col gap-6 sm:gap-8 h-full">
-          <!-- Portfolio Link Card -->
-          <a class="group flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-8 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30 flex-1"
+          <!-- Row 1 Col 3: Availability Sidebar -->
+          <div class="flex flex-col gap-3 rounded-2xl bg-surface border border-white/5 p-6">
+            <div class="flex items-center gap-3">
+              <span class="material-symbols-outlined text-primary">location_on</span>
+              <div>
+                <p class="text-white font-medium text-sm">Berlin, Germany</p>
+                <p class="text-white/50 text-xs">Open to opportunities</p>
+              </div>
+            </div>
+            <div class="h-px bg-white/5"></div>
+            <a href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
+              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
+              onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'sidebar',location:'hero_sidebar'})}">
+              <i class="fab fa-linkedin text-lg text-primary shrink-0"></i>
+              <span class="text-white/70 group-hover:text-white text-sm transition-colors">LinkedIn</span>
+              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
+            </a>
+            <a href="https://github.com/matthew-thaokhamlue" target="_blank"
+              class="flex items-center gap-3 p-3 rounded-xl hover:bg-white/5 transition-colors group"
+              onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'github',link_type:'sidebar',location:'hero_sidebar'})}">
+              <i class="fab fa-github text-lg text-white/60 shrink-0"></i>
+              <span class="text-white/70 group-hover:text-white text-sm transition-colors">GitHub</span>
+              <span class="material-symbols-outlined text-xs text-white/30 ml-auto">open_in_new</span>
+            </a>
+            <div class="h-px bg-white/5"></div>
+            <a href="Matthew main CV.pdf" target="_blank" rel="noopener noreferrer"
+              class="flex items-center justify-center gap-2 mt-auto h-10 px-4 bg-primary hover:bg-primary-dark text-white text-sm font-bold rounded-xl transition-colors shadow-lg shadow-primary/20"
+              onclick="if(typeof gtag==='function'){gtag('event','resume_downloaded',{file_name:'Matthew main CV.pdf',page_location:'index'})}">
+              <span class="material-symbols-outlined text-sm">download</span>
+              Download CV
+            </a>
+          </div>
+
+          <!-- Row 2: 3 compact action cards -->
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
             href="portfolio.html">
-            <div>
-              <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-4">
-                <span class="material-symbols-outlined text-2xl">grid_view</span>
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">grid_view</span>
               </div>
-              <h3 class="text-2xl font-bold tracking-tight text-white">Matthew's Portfolio</h3>
-              <p class="text-white/60 mt-2">Explore my work in leading cross-functional teams.</p>
+              <div>
+                <h3 class="font-bold text-white">Portfolio</h3>
+                <p class="text-white/50 text-sm">Explore my work</p>
+              </div>
             </div>
-            <div class="flex items-center gap-2 text-primary font-medium mt-4">
-              <span>View Portfolio</span>
-              <span
-                class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
-            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
           </a>
 
-          <!-- Download CV Card -->
-          <a class="group flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-8 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30 flex-1"
-            href="Matthew main CV.pdf" target="_blank" rel="noopener noreferrer"
-            onclick="if(typeof gtag==='function'){gtag('event','resume_downloaded',{file_name:'Matthew main CV.pdf',page_location:'index'})}">
-            <div>
-              <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-4">
-                <span class="material-symbols-outlined text-2xl">download</span>
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-5 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
+            href="experience.html">
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">description</span>
               </div>
-              <h3 class="text-2xl font-bold tracking-tight text-white">Download CV</h3>
-              <p class="text-white/60 mt-2">Get a copy of my resume and detailed work history.</p>
+              <div>
+                <h3 class="font-bold text-white">Experience</h3>
+                <p class="text-white/50 text-sm">Skills &amp; certifications</p>
+              </div>
             </div>
-            <div class="flex items-center gap-2 text-primary font-medium mt-4">
-              <span>Download PDF</span>
-              <span
-                class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_downward</span>
-            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
           </a>
+
+          <a class="group flex items-center justify-between gap-4 rounded-2xl bg-primary/10 border border-primary/20 p-5 transition-all duration-300 hover:bg-primary/20 hover:-translate-y-1"
+            href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
+            onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'cta_button',location:'hero_section'})}">
+            <div class="flex items-center gap-4">
+              <div class="size-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <span class="material-symbols-outlined">person_add</span>
+              </div>
+              <div>
+                <h3 class="font-bold text-white">Let's Connect</h3>
+                <p class="text-white/50 text-sm">Get in touch</p>
+              </div>
+            </div>
+            <span class="material-symbols-outlined text-primary transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
+          </a>
+
         </div>
-
-        <!-- Resume Link Card -->
-        <a class="group flex flex-col justify-between gap-4 rounded-2xl bg-surface border border-white/5 p-8 transition-all duration-300 hover:bg-surface-hover hover:-translate-y-1 hover:border-primary/30"
-          href="experience.html">
-          <div>
-            <div class="size-12 rounded-full bg-primary/10 flex items-center justify-center text-primary mb-4">
-              <span class="material-symbols-outlined text-2xl">description</span>
-            </div>
-            <h3 class="text-2xl font-bold tracking-tight text-white">Experience & Skills</h3>
-            <p class="text-white/60 mt-2">A detailed overview of my professional journey, skills, and certifications.
-            </p>
-          </div>
-          <div class="flex items-center gap-2 text-primary font-medium mt-4">
-            <span>View Experience</span>
-            <span
-              class="material-symbols-outlined transition-transform duration-300 group-hover:translate-x-1">arrow_forward</span>
-          </div>
-        </a>
-
-        <!-- Contact Card -->
-        <a class="group lg:col-span-2 flex flex-col sm:flex-row sm:items-center justify-between gap-6 rounded-2xl bg-primary/10 border border-primary/20 p-8 transition-all duration-300 hover:bg-primary/20 hover:-translate-y-1"
-          href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
-          onclick="if(typeof gtag==='function'){gtag('event','external_link_clicked',{destination_platform:'linkedin',link_type:'cta_button',location:'hero_section'})}">
-          <div class="flex-1">
-            <h3 class="text-2xl font-bold tracking-tight text-white">Let's Connect</h3>
-            <p class="text-white/70 mt-2">Have a project in mind or want to talk about product? I'd love to hear from
-              you.</p>
-          </div>
-          <button
-            class="flex shrink-0 items-center justify-center gap-2 h-12 px-6 bg-primary hover:bg-primary-dark text-white font-bold tracking-wide rounded-xl transition-colors shadow-lg shadow-primary/20">
-            <span>Get in Touch</span>
-            <span class="material-symbols-outlined">email</span>
-          </button>
-        </a>
       </section>
 
       <!-- Testimonials Section -->
-      <section id="testimonials" class="relative z-20 w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24">
+      <section id="testimonials" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
         <div class="max-w-7xl mx-auto flex flex-col gap-12">
-        <div class="flex flex-col gap-4 text-center items-center">
-          <div class="flex items-center gap-2 text-primary">
-            <span class="material-symbols-outlined">forum</span>
-            <h3 class="font-bold tracking-wide uppercase text-sm">Testimonials</h3>
+          <div class="flex flex-col gap-4 text-center items-center">
+            <div class="flex items-center gap-2 text-primary">
+              <span class="material-symbols-outlined">forum</span>
+              <h3 class="font-bold tracking-wide uppercase text-sm">Testimonials</h3>
+            </div>
+            <h2 class="text-3xl sm:text-5xl font-bold">What Colleagues Say</h2>
+            <a href="https://www.linkedin.com/in/matthewthaokhamlue/details/recommendations/" target="_blank"
+              rel="noopener noreferrer" onclick="if(typeof gtag==="
+              function"){gtag("event","external_link_clicked",{destination_platform:"linkedin",link_type:"recommendations_score",location:"testimonials_section"})}"
+              class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:text-white hover:border-primary/30 hover:bg-primary/10 transition-all duration-200">
+              <svg class="size-4 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                <path
+                  d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+              </svg>
+              <span>7 recommendations on LinkedIn</span>
+              <span class="material-symbols-outlined text-base">open_in_new</span>
+            </a>
           </div>
-          <h2 class="text-3xl sm:text-5xl font-bold">What Colleagues Say</h2>
-          <a href="https://www.linkedin.com/in/matthewthaokhamlue/details/recommendations/" target="_blank" rel="noopener noreferrer"
-            onclick="if(typeof gtag==="function"){gtag("event","external_link_clicked",{destination_platform:"linkedin",link_type:"recommendations_score",location:"testimonials_section"})}"
-            class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 border border-white/10 text-sm text-white/70 hover:text-white hover:border-primary/30 hover:bg-primary/10 transition-all duration-200">
-            <svg class="size-4 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
-            <span>7 recommendations on LinkedIn</span>
-            <span class="material-symbols-outlined text-base">open_in_new</span>
-          </a>
-        </div>
-        <!-- Testimonials Marquee -->
-        <div class="w-full overflow-hidden" style="mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent); -webkit-mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);">
-          <div class="marquee-track flex gap-6" style="width: max-content;">
-<div onclick="openTestimonial(this)" data-name="Paul Burggraf" data-role="Founder at Thryve"
-            data-image="images/PB.jpeg"
-            data-text="Matthew joined Thryve as the 7th employee. He has been pivotal in building our quality assurance team, our customer operations team and our product team. As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and demanding field of health care from 1k end users to over 1 million end users. Matthew has steered our agile development process as a scrum master. He worked closely with the c-level, front end team, back end team and quality assurance team to plan, execute and review sprints and releases. In this role, he showed exceptional dedication, hands-on attitude and a great technical understanding. Matthew massively contributed to Thryve's growth and professionalization. The whole team is grateful to have worked with him and sad to let him go. I am sure Matthew will continue to manage big IT projects and scale complex operations convincingly."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/PB.jpeg" alt="Paul Burggraf"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Paul Burggraf</h4>
-                <p class="text-primary text-sm">Founder at Thryve</p>
+          <!-- Testimonials Marquee -->
+          <div class="w-full overflow-hidden"
+            style="mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent); -webkit-mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);">
+            <div class="marquee-track flex gap-6" style="width: max-content;">
+              <div onclick="openTestimonial(this)" data-name="Paul Burggraf" data-role="Founder at Thryve"
+                data-image="images/PB.jpeg"
+                data-text="Matthew joined Thryve as the 7th employee. He has been pivotal in building our quality assurance team, our customer operations team and our product team. As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and demanding field of health care from 1k end users to over 1 million end users. Matthew has steered our agile development process as a scrum master. He worked closely with the c-level, front end team, back end team and quality assurance team to plan, execute and review sprints and releases. In this role, he showed exceptional dedication, hands-on attitude and a great technical understanding. Matthew massively contributed to Thryve's growth and professionalization. The whole team is grateful to have worked with him and sad to let him go. I am sure Matthew will continue to manage big IT projects and scale complex operations convincingly."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/PB.jpeg" alt="Paul Burggraf"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Paul Burggraf</h4>
+                    <p class="text-primary text-sm">Founder at Thryve</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew joined Thryve as the 7th
+                  employee...
+                  As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and
+                  demanding field of health care from 1k end users to over 1 million end users."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Jeroen de Haas" data-role="CPO at Labforward"
+                data-image="images/jeroen-de-haas.png"
+                data-text="I've had the privilege of working closely with Matt as his manager and CPO, and watching his journey has been one of the most rewarding parts of my role. From the moment he joined the team, Matt stood out as a fast learner—someone who not only picks up complex concepts quickly but also asks the right questions to get to the heart of a problem. What I admire most is his genuine can-do attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus, turning ideas into tangible outcomes. I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads with empathy and clarity. His growth isn't just in skills, but in the way he brings people together. Matt is a natural team player who listens, collaborates, and makes everyone around him better. He bridges gaps between engineering, design, and customer teams with ease, always keeping the bigger picture in mind while never losing sight of the details that matter. If you're looking for someone who combines sharp product thinking with humility, grit, and genuine care for the team, Matt is that person. I feel lucky to have worked with him and can't wait to see where his talents take him next."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/jeroen-de-haas.png" alt="Jeroen de Haas"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Jeroen de Haas</h4>
+                    <p class="text-primary text-sm">CPO at Labforward</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"What I admire most is his genuine can-do
+                  attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and
+                  focus...
+                  I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Robin Genolet"
+                data-role="Director Innovation & AI at Medgate" data-image="images/robin-genolet.jpeg"
+                data-text="At Medgate, we partnered with Berlin-based company mHealth Pioneers GmbH and use their Thryve product since July 2021. We use Thryve's standardized API and SDK to allow our patients to securely share with us sensor-generated data from hundreds of health devices via our mobile app. We then make the data available to our Doctors to support their teleconsultations. Their API standardizes the dozens of data formats used by a wide range of brands like Garmin, Fitbit, and Apple Healthkit. Thryve allowed us to minimize the duration of our development phase and takes care of the maintenance necessary when a data provider updates its API. We are both happy with the product and the team behind it: Matthew (Thryve Product Owner) and colleagues not only provided useful guidance during the development phase, but also helped us deal with challenges encountered with the brands we support, and also assisted us on our medical affairs and marketing streams."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/robin-genolet.jpeg" alt="Robin Genolet"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Robin Genolet</h4>
+                    <p class="text-primary text-sm">Director Innovation & AI at Medgate</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew (Thryve Product Owner) and
+                  colleagues
+                  not only
+                  provided useful guidance during the development phase, but also helped us deal with challenges
+                  encountered
+                  with
+                  the brands we support..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Ignatius Reza" data-role="CTO at Laboperator"
+                data-image="images/ignatius-reza.jpeg"
+                data-text="Matthew is a great product manager with technical chops. He is great in digesting the complex area of developing a product which are highly technical, and coming up with product direction that is easy to understand and use. He's also a great person to have in the team. Great presence, character, motivation, and always willing to support."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/ignatius-reza.jpeg" alt="Ignatius Reza"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Ignatius Reza</h4>
+                    <p class="text-primary text-sm">CTO at Laboperator</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew is a great product manager with
+                  technical
+                  chops. He is great in digesting the complex area of developing a product which are highly technical,
+                  and
+                  coming
+                  up with product direction that is easy to understand and use..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Sumner Price" data-role="Product Designer"
+                data-image="images/sumner-price.jpeg"
+                data-text="I had the pleasure of working with Matt on many projects within our product team. He consistently impressed me with how quickly he picked up new initiatives and guided them through the product development process. As a product manager, Matt communicated clearly and ensured all relevant stakeholders were always aligned. He was my go-to person whenever I felt uncertain about something. On top of that, his organizational skills—especially in creating PRDs and managing tickets—were invaluable. Working with him was truly a joy!"
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/sumner-price.jpeg" alt="Sumner Price"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Sumner Price</h4>
+                    <p class="text-primary text-sm">Product Designer at Labforward</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"He consistently impressed me with how
+                  quickly
+                  he
+                  picked up new initiatives and guided them through the product development process. As a product
+                  manager,
+                  Matt
+                  communicated clearly and ensured all relevant stakeholders were always aligned..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Mark Dominick Flores"
+                data-role="Senior iOS Engineer at LabTwin" data-image="images/mark-flores.png"
+                data-text="I highly recommend Matthew, my former Technical Product Manager. I worked with him on a number of features, and his contributions were critical to getting them shipped. Matthew has a remarkable ability to take nebulous business requirements and translate them into a clear, actionable backlog for the engineering team. He's also an incredibly fast learner. He quickly got up to speed on our complex systems and made smart, informed decisions on what to prioritize to maximize impact with minimal overhead. On a personal level, he's great to work with. He was always available to unblock us, help us navigate dependencies, and make sure we had the context we needed to build things correctly the first time. Matthew is a top-tier TPM, and I'd work with him again in a heartbeat. He's a huge asset to any product or engineering team."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/mark-flores.png" alt="Mark Dominick Flores"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Mark Dominick Flores</h4>
+                    <p class="text-primary text-sm">Senior iOS Engineer at LabTwin</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew has a remarkable ability to take
+                  nebulous business requirements and translate them into a clear, actionable backlog... He's also an
+                  incredibly fast learner. He quickly got up to speed on our complex systems."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Thuy Tran" data-role="Software Engineer at Doctorlib"
+                data-image=""
+                data-text="I worked with Matthew for more than 3 years in a cross-functional team where he was the Production Owner. I was extremely impressed with his analytical mind and his ability to dig deep and notice even the small details of a software feature. With his attitude of can-do and let's get thing done, as well as his ability to pick things up quickly, his contribution to the team was highly significant and valuable. It was always a pleasure to co-work with him, as he takes his responsibility very seriously while maintaining a pleasant, collaborative discussion. I could always count on him to complete his tasks with full efforts and excellent output, and his supportive nature towards our colleagues."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <div
+                    class="w-14 h-14 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold text-xl">
+                    TT</div>
+                  <div>
+                    <h4 class="font-bold text-white">Thuy Tran</h4>
+                    <p class="text-primary text-sm">Software Engineer at Doctorlib</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"I was extremely impressed with his
+                  analytical
+                  mind and his ability to dig deep and notice even the small details of a software feature. With his
+                  attitude of can-do and let's get thing done... his contribution to the team was highly significant."
+                </p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Paul Burggraf" data-role="Founder at Thryve"
+                data-image="images/PB.jpeg"
+                data-text="Matthew joined Thryve as the 7th employee. He has been pivotal in building our quality assurance team, our customer operations team and our product team. As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and demanding field of health care from 1k end users to over 1 million end users. Matthew has steered our agile development process as a scrum master. He worked closely with the c-level, front end team, back end team and quality assurance team to plan, execute and review sprints and releases. In this role, he showed exceptional dedication, hands-on attitude and a great technical understanding. Matthew massively contributed to Thryve's growth and professionalization. The whole team is grateful to have worked with him and sad to let him go. I am sure Matthew will continue to manage big IT projects and scale complex operations convincingly."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/PB.jpeg" alt="Paul Burggraf"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Paul Burggraf</h4>
+                    <p class="text-primary text-sm">Founder at Thryve</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew joined Thryve as the 7th
+                  employee...
+                  As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and
+                  demanding field of health care from 1k end users to over 1 million end users."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Jeroen de Haas" data-role="CPO at Labforward"
+                data-image="images/jeroen-de-haas.png"
+                data-text="I've had the privilege of working closely with Matt as his manager and CPO, and watching his journey has been one of the most rewarding parts of my role. From the moment he joined the team, Matt stood out as a fast learner—someone who not only picks up complex concepts quickly but also asks the right questions to get to the heart of a problem. What I admire most is his genuine can-do attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus, turning ideas into tangible outcomes. I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads with empathy and clarity. His growth isn't just in skills, but in the way he brings people together. Matt is a natural team player who listens, collaborates, and makes everyone around him better. He bridges gaps between engineering, design, and customer teams with ease, always keeping the bigger picture in mind while never losing sight of the details that matter. If you're looking for someone who combines sharp product thinking with humility, grit, and genuine care for the team, Matt is that person. I feel lucky to have worked with him and can't wait to see where his talents take him next."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/jeroen-de-haas.png" alt="Jeroen de Haas"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Jeroen de Haas</h4>
+                    <p class="text-primary text-sm">CPO at Labforward</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"What I admire most is his genuine can-do
+                  attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and
+                  focus...
+                  I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Robin Genolet"
+                data-role="Director Innovation & AI at Medgate" data-image="images/robin-genolet.jpeg"
+                data-text="At Medgate, we partnered with Berlin-based company mHealth Pioneers GmbH and use their Thryve product since July 2021. We use Thryve's standardized API and SDK to allow our patients to securely share with us sensor-generated data from hundreds of health devices via our mobile app. We then make the data available to our Doctors to support their teleconsultations. Their API standardizes the dozens of data formats used by a wide range of brands like Garmin, Fitbit, and Apple Healthkit. Thryve allowed us to minimize the duration of our development phase and takes care of the maintenance necessary when a data provider updates its API. We are both happy with the product and the team behind it: Matthew (Thryve Product Owner) and colleagues not only provided useful guidance during the development phase, but also helped us deal with challenges encountered with the brands we support, and also assisted us on our medical affairs and marketing streams."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/robin-genolet.jpeg" alt="Robin Genolet"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Robin Genolet</h4>
+                    <p class="text-primary text-sm">Director Innovation & AI at Medgate</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew (Thryve Product Owner) and
+                  colleagues
+                  not only
+                  provided useful guidance during the development phase, but also helped us deal with challenges
+                  encountered
+                  with
+                  the brands we support..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Ignatius Reza" data-role="CTO at Laboperator"
+                data-image="images/ignatius-reza.jpeg"
+                data-text="Matthew is a great product manager with technical chops. He is great in digesting the complex area of developing a product which are highly technical, and coming up with product direction that is easy to understand and use. He's also a great person to have in the team. Great presence, character, motivation, and always willing to support."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/ignatius-reza.jpeg" alt="Ignatius Reza"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Ignatius Reza</h4>
+                    <p class="text-primary text-sm">CTO at Laboperator</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew is a great product manager with
+                  technical
+                  chops. He is great in digesting the complex area of developing a product which are highly technical,
+                  and
+                  coming
+                  up with product direction that is easy to understand and use..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Sumner Price" data-role="Product Designer"
+                data-image="images/sumner-price.jpeg"
+                data-text="I had the pleasure of working with Matt on many projects within our product team. He consistently impressed me with how quickly he picked up new initiatives and guided them through the product development process. As a product manager, Matt communicated clearly and ensured all relevant stakeholders were always aligned. He was my go-to person whenever I felt uncertain about something. On top of that, his organizational skills—especially in creating PRDs and managing tickets—were invaluable. Working with him was truly a joy!"
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/sumner-price.jpeg" alt="Sumner Price"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Sumner Price</h4>
+                    <p class="text-primary text-sm">Product Designer at Labforward</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"He consistently impressed me with how
+                  quickly
+                  he
+                  picked up new initiatives and guided them through the product development process. As a product
+                  manager,
+                  Matt
+                  communicated clearly and ensured all relevant stakeholders were always aligned..."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Mark Dominick Flores"
+                data-role="Senior iOS Engineer at LabTwin" data-image="images/mark-flores.png"
+                data-text="I highly recommend Matthew, my former Technical Product Manager. I worked with him on a number of features, and his contributions were critical to getting them shipped. Matthew has a remarkable ability to take nebulous business requirements and translate them into a clear, actionable backlog for the engineering team. He's also an incredibly fast learner. He quickly got up to speed on our complex systems and made smart, informed decisions on what to prioritize to maximize impact with minimal overhead. On a personal level, he's great to work with. He was always available to unblock us, help us navigate dependencies, and make sure we had the context we needed to build things correctly the first time. Matthew is a top-tier TPM, and I'd work with him again in a heartbeat. He's a huge asset to any product or engineering team."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <img src="images/mark-flores.png" alt="Mark Dominick Flores"
+                    class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
+                  <div>
+                    <h4 class="font-bold text-white">Mark Dominick Flores</h4>
+                    <p class="text-primary text-sm">Senior iOS Engineer at LabTwin</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew has a remarkable ability to take
+                  nebulous business requirements and translate them into a clear, actionable backlog... He's also an
+                  incredibly fast learner. He quickly got up to speed on our complex systems."</p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
+              </div>
+              <div onclick="openTestimonial(this)" data-name="Thuy Tran" data-role="Software Engineer at Doctorlib"
+                data-image=""
+                data-text="I worked with Matthew for more than 3 years in a cross-functional team where he was the Production Owner. I was extremely impressed with his analytical mind and his ability to dig deep and notice even the small details of a software feature. With his attitude of can-do and let's get thing done, as well as his ability to pick things up quickly, his contribution to the team was highly significant and valuable. It was always a pleasure to co-work with him, as he takes his responsibility very seriously while maintaining a pleasant, collaborative discussion. I could always count on him to complete his tasks with full efforts and excellent output, and his supportive nature towards our colleagues."
+                class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
+                <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
+                <div class="flex items-center gap-4">
+                  <div
+                    class="w-14 h-14 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold text-xl">
+                    TT</div>
+                  <div>
+                    <h4 class="font-bold text-white">Thuy Tran</h4>
+                    <p class="text-primary text-sm">Software Engineer at Doctorlib</p>
+                  </div>
+                </div>
+                <p class="text-white/70 italic leading-relaxed line-clamp-3">"I was extremely impressed with his
+                  analytical
+                  mind and his ability to dig deep and notice even the small details of a software feature. With his
+                  attitude of can-do and let's get thing done... his contribution to the team was highly significant."
+                </p>
+                <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
               </div>
             </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew joined Thryve as the 7th employee...
-              As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and
-              demanding field of health care from 1k end users to over 1 million end users."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
           </div>
-<div onclick="openTestimonial(this)" data-name="Jeroen de Haas" data-role="CPO at Labforward"
-            data-image="images/jeroen-de-haas.png"
-            data-text="I've had the privilege of working closely with Matt as his manager and CPO, and watching his journey has been one of the most rewarding parts of my role. From the moment he joined the team, Matt stood out as a fast learner—someone who not only picks up complex concepts quickly but also asks the right questions to get to the heart of a problem. What I admire most is his genuine can-do attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus, turning ideas into tangible outcomes. I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads with empathy and clarity. His growth isn't just in skills, but in the way he brings people together. Matt is a natural team player who listens, collaborates, and makes everyone around him better. He bridges gaps between engineering, design, and customer teams with ease, always keeping the bigger picture in mind while never losing sight of the details that matter. If you're looking for someone who combines sharp product thinking with humility, grit, and genuine care for the team, Matt is that person. I feel lucky to have worked with him and can't wait to see where his talents take him next."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/jeroen-de-haas.png" alt="Jeroen de Haas"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Jeroen de Haas</h4>
-                <p class="text-primary text-sm">CPO at Labforward</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"What I admire most is his genuine can-do
-              attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus...
-              I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Robin Genolet" data-role="Director Innovation & AI at Medgate"
-            data-image="images/robin-genolet.jpeg"
-            data-text="At Medgate, we partnered with Berlin-based company mHealth Pioneers GmbH and use their Thryve product since July 2021. We use Thryve's standardized API and SDK to allow our patients to securely share with us sensor-generated data from hundreds of health devices via our mobile app. We then make the data available to our Doctors to support their teleconsultations. Their API standardizes the dozens of data formats used by a wide range of brands like Garmin, Fitbit, and Apple Healthkit. Thryve allowed us to minimize the duration of our development phase and takes care of the maintenance necessary when a data provider updates its API. We are both happy with the product and the team behind it: Matthew (Thryve Product Owner) and colleagues not only provided useful guidance during the development phase, but also helped us deal with challenges encountered with the brands we support, and also assisted us on our medical affairs and marketing streams."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/robin-genolet.jpeg" alt="Robin Genolet"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Robin Genolet</h4>
-                <p class="text-primary text-sm">Director Innovation & AI at Medgate</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew (Thryve Product Owner) and colleagues
-              not only
-              provided useful guidance during the development phase, but also helped us deal with challenges encountered
-              with
-              the brands we support..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Ignatius Reza" data-role="CTO at Laboperator"
-            data-image="images/ignatius-reza.jpeg"
-            data-text="Matthew is a great product manager with technical chops. He is great in digesting the complex area of developing a product which are highly technical, and coming up with product direction that is easy to understand and use. He's also a great person to have in the team. Great presence, character, motivation, and always willing to support."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/ignatius-reza.jpeg" alt="Ignatius Reza"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Ignatius Reza</h4>
-                <p class="text-primary text-sm">CTO at Laboperator</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew is a great product manager with
-              technical
-              chops. He is great in digesting the complex area of developing a product which are highly technical, and
-              coming
-              up with product direction that is easy to understand and use..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Sumner Price" data-role="Product Designer"
-            data-image="images/sumner-price.jpeg"
-            data-text="I had the pleasure of working with Matt on many projects within our product team. He consistently impressed me with how quickly he picked up new initiatives and guided them through the product development process. As a product manager, Matt communicated clearly and ensured all relevant stakeholders were always aligned. He was my go-to person whenever I felt uncertain about something. On top of that, his organizational skills—especially in creating PRDs and managing tickets—were invaluable. Working with him was truly a joy!"
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/sumner-price.jpeg" alt="Sumner Price"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Sumner Price</h4>
-                <p class="text-primary text-sm">Product Designer at Labforward</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"He consistently impressed me with how quickly
-              he
-              picked up new initiatives and guided them through the product development process. As a product manager,
-              Matt
-              communicated clearly and ensured all relevant stakeholders were always aligned..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Mark Dominick Flores"
-            data-role="Senior iOS Engineer at LabTwin" data-image="images/mark-flores.png"
-            data-text="I highly recommend Matthew, my former Technical Product Manager. I worked with him on a number of features, and his contributions were critical to getting them shipped. Matthew has a remarkable ability to take nebulous business requirements and translate them into a clear, actionable backlog for the engineering team. He's also an incredibly fast learner. He quickly got up to speed on our complex systems and made smart, informed decisions on what to prioritize to maximize impact with minimal overhead. On a personal level, he's great to work with. He was always available to unblock us, help us navigate dependencies, and make sure we had the context we needed to build things correctly the first time. Matthew is a top-tier TPM, and I'd work with him again in a heartbeat. He's a huge asset to any product or engineering team."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/mark-flores.png" alt="Mark Dominick Flores"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Mark Dominick Flores</h4>
-                <p class="text-primary text-sm">Senior iOS Engineer at LabTwin</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew has a remarkable ability to take
-              nebulous business requirements and translate them into a clear, actionable backlog... He's also an
-              incredibly fast learner. He quickly got up to speed on our complex systems."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Thuy Tran" data-role="Software Engineer at Doctorlib"
-            data-image=""
-            data-text="I worked with Matthew for more than 3 years in a cross-functional team where he was the Production Owner. I was extremely impressed with his analytical mind and his ability to dig deep and notice even the small details of a software feature. With his attitude of can-do and let's get thing done, as well as his ability to pick things up quickly, his contribution to the team was highly significant and valuable. It was always a pleasure to co-work with him, as he takes his responsibility very seriously while maintaining a pleasant, collaborative discussion. I could always count on him to complete his tasks with full efforts and excellent output, and his supportive nature towards our colleagues."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <div
-                class="w-14 h-14 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold text-xl">
-                TT</div>
-              <div>
-                <h4 class="font-bold text-white">Thuy Tran</h4>
-                <p class="text-primary text-sm">Software Engineer at Doctorlib</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"I was extremely impressed with his analytical
-              mind and his ability to dig deep and notice even the small details of a software feature. With his
-              attitude of can-do and let's get thing done... his contribution to the team was highly significant."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Paul Burggraf" data-role="Founder at Thryve"
-            data-image="images/PB.jpeg"
-            data-text="Matthew joined Thryve as the 7th employee. He has been pivotal in building our quality assurance team, our customer operations team and our product team. As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and demanding field of health care from 1k end users to over 1 million end users. Matthew has steered our agile development process as a scrum master. He worked closely with the c-level, front end team, back end team and quality assurance team to plan, execute and review sprints and releases. In this role, he showed exceptional dedication, hands-on attitude and a great technical understanding. Matthew massively contributed to Thryve's growth and professionalization. The whole team is grateful to have worked with him and sad to let him go. I am sure Matthew will continue to manage big IT projects and scale complex operations convincingly."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/PB.jpeg" alt="Paul Burggraf"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Paul Burggraf</h4>
-                <p class="text-primary text-sm">Founder at Thryve</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew joined Thryve as the 7th employee...
-              As a product owner, he has managed to scale a complex and unique IT service in a highly regulated and
-              demanding field of health care from 1k end users to over 1 million end users."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Jeroen de Haas" data-role="CPO at Labforward"
-            data-image="images/jeroen-de-haas.png"
-            data-text="I've had the privilege of working closely with Matt as his manager and CPO, and watching his journey has been one of the most rewarding parts of my role. From the moment he joined the team, Matt stood out as a fast learner—someone who not only picks up complex concepts quickly but also asks the right questions to get to the heart of a problem. What I admire most is his genuine can-do attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus, turning ideas into tangible outcomes. I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads with empathy and clarity. His growth isn't just in skills, but in the way he brings people together. Matt is a natural team player who listens, collaborates, and makes everyone around him better. He bridges gaps between engineering, design, and customer teams with ease, always keeping the bigger picture in mind while never losing sight of the details that matter. If you're looking for someone who combines sharp product thinking with humility, grit, and genuine care for the team, Matt is that person. I feel lucky to have worked with him and can't wait to see where his talents take him next."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/jeroen-de-haas.png" alt="Jeroen de Haas"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Jeroen de Haas</h4>
-                <p class="text-primary text-sm">CPO at Labforward</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"What I admire most is his genuine can-do
-              attitude. No matter how ambiguous or challenging the situation, Matt dives in with curiosity and focus...
-              I've truly seen him grow—from confidently shaping roadmaps to leading cross-functional squads."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Robin Genolet" data-role="Director Innovation & AI at Medgate"
-            data-image="images/robin-genolet.jpeg"
-            data-text="At Medgate, we partnered with Berlin-based company mHealth Pioneers GmbH and use their Thryve product since July 2021. We use Thryve's standardized API and SDK to allow our patients to securely share with us sensor-generated data from hundreds of health devices via our mobile app. We then make the data available to our Doctors to support their teleconsultations. Their API standardizes the dozens of data formats used by a wide range of brands like Garmin, Fitbit, and Apple Healthkit. Thryve allowed us to minimize the duration of our development phase and takes care of the maintenance necessary when a data provider updates its API. We are both happy with the product and the team behind it: Matthew (Thryve Product Owner) and colleagues not only provided useful guidance during the development phase, but also helped us deal with challenges encountered with the brands we support, and also assisted us on our medical affairs and marketing streams."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/robin-genolet.jpeg" alt="Robin Genolet"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Robin Genolet</h4>
-                <p class="text-primary text-sm">Director Innovation & AI at Medgate</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew (Thryve Product Owner) and colleagues
-              not only
-              provided useful guidance during the development phase, but also helped us deal with challenges encountered
-              with
-              the brands we support..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Ignatius Reza" data-role="CTO at Laboperator"
-            data-image="images/ignatius-reza.jpeg"
-            data-text="Matthew is a great product manager with technical chops. He is great in digesting the complex area of developing a product which are highly technical, and coming up with product direction that is easy to understand and use. He's also a great person to have in the team. Great presence, character, motivation, and always willing to support."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/ignatius-reza.jpeg" alt="Ignatius Reza"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Ignatius Reza</h4>
-                <p class="text-primary text-sm">CTO at Laboperator</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew is a great product manager with
-              technical
-              chops. He is great in digesting the complex area of developing a product which are highly technical, and
-              coming
-              up with product direction that is easy to understand and use..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Sumner Price" data-role="Product Designer"
-            data-image="images/sumner-price.jpeg"
-            data-text="I had the pleasure of working with Matt on many projects within our product team. He consistently impressed me with how quickly he picked up new initiatives and guided them through the product development process. As a product manager, Matt communicated clearly and ensured all relevant stakeholders were always aligned. He was my go-to person whenever I felt uncertain about something. On top of that, his organizational skills—especially in creating PRDs and managing tickets—were invaluable. Working with him was truly a joy!"
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/sumner-price.jpeg" alt="Sumner Price"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Sumner Price</h4>
-                <p class="text-primary text-sm">Product Designer at Labforward</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"He consistently impressed me with how quickly
-              he
-              picked up new initiatives and guided them through the product development process. As a product manager,
-              Matt
-              communicated clearly and ensured all relevant stakeholders were always aligned..."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Mark Dominick Flores"
-            data-role="Senior iOS Engineer at LabTwin" data-image="images/mark-flores.png"
-            data-text="I highly recommend Matthew, my former Technical Product Manager. I worked with him on a number of features, and his contributions were critical to getting them shipped. Matthew has a remarkable ability to take nebulous business requirements and translate them into a clear, actionable backlog for the engineering team. He's also an incredibly fast learner. He quickly got up to speed on our complex systems and made smart, informed decisions on what to prioritize to maximize impact with minimal overhead. On a personal level, he's great to work with. He was always available to unblock us, help us navigate dependencies, and make sure we had the context we needed to build things correctly the first time. Matthew is a top-tier TPM, and I'd work with him again in a heartbeat. He's a huge asset to any product or engineering team."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <img src="images/mark-flores.png" alt="Mark Dominick Flores"
-                class="w-14 h-14 rounded-full object-cover border-2 border-primary/20">
-              <div>
-                <h4 class="font-bold text-white">Mark Dominick Flores</h4>
-                <p class="text-primary text-sm">Senior iOS Engineer at LabTwin</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"Matthew has a remarkable ability to take
-              nebulous business requirements and translate them into a clear, actionable backlog... He's also an
-              incredibly fast learner. He quickly got up to speed on our complex systems."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-<div onclick="openTestimonial(this)" data-name="Thuy Tran" data-role="Software Engineer at Doctorlib"
-            data-image=""
-            data-text="I worked with Matthew for more than 3 years in a cross-functional team where he was the Production Owner. I was extremely impressed with his analytical mind and his ability to dig deep and notice even the small details of a software feature. With his attitude of can-do and let's get thing done, as well as his ability to pick things up quickly, his contribution to the team was highly significant and valuable. It was always a pleasure to co-work with him, as he takes his responsibility very seriously while maintaining a pleasant, collaborative discussion. I could always count on him to complete his tasks with full efforts and excellent output, and his supportive nature towards our colleagues."
-            class="flex-shrink-0 w-[340px] cursor-pointer flex flex-col gap-5 p-6 rounded-2xl bg-surface border border-white/5 relative hover:bg-surface-hover transition-colors group">
-            <span class="material-symbols-outlined text-6xl text-white/5 absolute top-6 right-6">format_quote</span>
-            <div class="flex items-center gap-4">
-              <div
-                class="w-14 h-14 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold text-xl">
-                TT</div>
-              <div>
-                <h4 class="font-bold text-white">Thuy Tran</h4>
-                <p class="text-primary text-sm">Software Engineer at Doctorlib</p>
-              </div>
-            </div>
-            <p class="text-white/70 italic leading-relaxed line-clamp-3">"I was extremely impressed with his analytical
-              mind and his ability to dig deep and notice even the small details of a software feature. With his
-              attitude of can-do and let's get thing done... his contribution to the team was highly significant."</p>
-            <p class="text-primary text-sm font-medium mt-auto group-hover:underline">Read full testimonial</p>
-          </div>
-          </div>
-        </div>
         </div><!-- /testimonials-inner -->
       </section>
 
       <!-- My Story Section -->
-      <section id="my-story" class="relative z-30 w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24">
+      <section id="my-story" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:30">
         <div class="max-w-7xl mx-auto flex flex-col gap-12">
 
           <!-- Header -->
@@ -743,7 +796,8 @@
                 actually help them.
               </p>
               <p>
-                I care deeply about leading cross-functional teams with collaboration and clarity, delivering things that make users smile. Whether
+                I care deeply about leading cross-functional teams with collaboration and clarity, delivering things
+                that make users smile. Whether
                 it's streamlining a lab workflow or building health data infrastructure, I focus on bridging
                 technical complexity with human needs.
               </p>
@@ -770,8 +824,8 @@
     <footer class="border-t border-white/10 bg-background-dark py-12">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center gap-6">
         <div class="flex flex-col gap-2 text-center md:text-left">
-          <p class="text-white/60 text-sm">&copy; 2025 Matthew Thaokhamlue. All rights reserved.</p>
-          <p class="text-white/40 text-xs">Technical Product Manager | Berlin, Germany</p>
+          <p class="text-white/60 text-sm">&copy; 2026 Matthew Thaokhamlue. All rights reserved.</p>
+          <p class="text-white/40 text-xs">Product Manager | Berlin, Germany</p>
         </div>
         <div class="flex items-center gap-6">
           <a href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank"
@@ -820,6 +874,25 @@
     </div>
   </dialog>
 
+  <!-- Stacking scroll effect -->
+  <script>
+    (function () {
+      var panels = document.querySelectorAll('.stack-panel');
+      if (!panels.length) return;
+      function update() {
+        var vh = window.innerHeight;
+        panels.forEach(function (panel, i) {
+          var next = panels[i + 1];
+          if (!next) return;
+          var nextTop = next.getBoundingClientRect().top;
+          panel.classList.toggle('is-covered', nextTop < vh * 0.88);
+        });
+      }
+      window.addEventListener('scroll', update, { passive: true });
+      update();
+    })();
+  </script>
+
   <!-- AI Match Modal -->
   <dialog id="ai-match-modal"
     class="bg-transparent p-0 backdrop:bg-black/80 backdrop:backdrop-blur-sm w-full h-full max-w-full max-h-full m-0 items-center justify-center">
@@ -840,8 +913,10 @@
             <textarea id="ai-match-jd" rows="5"
               class="w-full rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/45 focus:border-primary/50 focus:ring-primary/20"
               placeholder="Paste the full job description here..."></textarea>
-            <p class="rounded-lg border border-amber-300/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-100/90">
-              ChatGPT tip: If an error appears after you paste, your job description is usually fine. Try shortening your job description first, or open ChatGPT in a private/incognito window.
+            <p
+              class="rounded-lg border border-amber-300/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-100/90">
+              ChatGPT tip: If an error appears after you paste, your job description is usually fine. Try shortening
+              your job description first, or open ChatGPT in a private/incognito window.
               <a id="ai-chatgpt-fallback-link" href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer"
                 class="ml-1 text-amber-100 underline hover:text-white">
                 Link doesn't work? Click here.

--- a/index.html
+++ b/index.html
@@ -739,7 +739,7 @@
           </div>
 
           <!-- Content -->
-          <div class="flex flex-col md:flex-row gap-12 items-start">
+          <div class="flex flex-col md:flex-row gap-12">
             <!-- Sidebar: Photo + Education -->
             <div class="md:w-[30%] shrink-0 flex flex-col gap-8">
               <div class="relative">
@@ -768,7 +768,7 @@
             </div>
 
             <!-- Story Text -->
-            <div class="md:w-[70%] flex flex-col gap-6 text-white/80 leading-relaxed text-lg overflow-y-auto max-h-[60vh] pr-4 custom-scrollbar">
+            <div class="md:w-[70%] flex flex-col gap-6 text-white/80 leading-relaxed text-lg overflow-y-auto h-full pr-4 custom-scrollbar">
               <p>
                 I still remember opening that letter. A DAAD scholarship to study in Berlin. I had to read it
                 three times to believe it was real. Me? Berlin? That moment taught me that taking a leap, even

--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
       </section>
 
       <!-- Testimonials Section -->
-      <section id="testimonials" class="stack-panel w-full bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24" style="--panel-z:20">
+      <section id="testimonials" class="stack-panel w-full h-screen bg-background-dark px-4 sm:px-6 lg:px-8 py-20 sm:py-24 overflow-hidden" style="--panel-z:20">
         <div class="max-w-7xl mx-auto flex flex-col gap-12">
           <div class="flex flex-col gap-4 text-center items-center">
             <div class="flex items-center gap-2 text-primary">


### PR DESCRIPTION
## Summary

- **`experience.html`**: Un-stuck the experience wrapper so all job cards & skills scroll freely; Certifications slides up as a sticky card at the end with rounded top corners and shadow
- **`index.html` hero**: Restored original 3-column bento layout, tightened padding/sizing to fit within `h-screen`
- **`index.html` testimonials**: Set to `h-screen` to match hero stack height
- **`index.html` My Story**: Story text div is now scrollable (`overflow-y-auto`, `max-h-[60vh]`) so the section stays within its stack panel

## Test plan

- [ ] `index.html`: Hero bento fits in viewport without scrolling
- [ ] Scroll down: Testimonials slides over hero as a card (compresses/dims hero)
- [ ] Scroll down: My Story slides over testimonials; story text is scrollable within the panel
- [ ] `experience.html`: All job cards + skills visible by scrolling freely; Certifications slides up as a rounded card at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)