### PR TITLE
Add light/dark theme toggle; default to Claude off-white light mode

### DIFF
--- a/assets/css/editorial.css
+++ b/assets/css/editorial.css
@@ -8,21 +8,36 @@
 
 /* ── editorial-tokens ── */
   :root {
-    /* palette — dark editorial */
-    --ed-bg:        #0a1014;
-    --ed-bg-soft:   #0f161b;
-    --ed-surface:   #131c22;
-    --ed-hairline:  rgba(255, 255, 255, 0.06);
-    --ed-hairline-strong: rgba(255, 255, 255, 0.12);
+    /* palette — light (Claude off-white), the default theme.
+       The original dark editorial palette lives in
+       :root[data-theme="dark"] below and is opt-in via the toggle. */
+    --ed-bg:        #f4f2ec;       /* warm ivory paper */
+    --ed-bg-soft:   #faf8f2;       /* raised card surface */
+    --ed-surface:   #efebe1;       /* insets, card hover */
+    --ed-hairline:  rgba(41, 38, 31, 0.10);
+    --ed-hairline-strong: rgba(41, 38, 31, 0.20);
 
-    --ed-ink:       #f3f5f7;       /* near-white primary */
-    --ed-ink-soft:  #c7cfd5;       /* secondary body */
-    --ed-ink-dim:   #8b969e;       /* tertiary captions */
-    --ed-ink-mute:  #5a656d;       /* labels, attribution */
+    --ed-ink:       #29261f;       /* warm near-black primary */
+    --ed-ink-soft:  #4a4640;       /* secondary body */
+    --ed-ink-dim:   #6e695f;       /* tertiary captions */
+    --ed-ink-mute:  #908a7e;       /* labels, attribution */
 
-    --ed-accent:        #4fb6dc;   /* desaturated cyan, editorial */
-    --ed-accent-strong: #6cc7e9;
-    --ed-accent-mute:   rgba(79, 182, 220, 0.16);
+    --ed-accent:        #c45a38;   /* Claude clay, decorative accent */
+    --ed-accent-strong: #a8431f;   /* deep terracotta, body-size accent text */
+    --ed-accent-mute:   rgba(196, 90, 56, 0.14);
+
+    /* themed surfaces (referenced where colors were once hardcoded) */
+    --ed-topbar-bg: rgba(244, 242, 236, 0.80);
+    --ed-menu-bg:   rgba(244, 242, 236, 0.97);
+    --ed-field-bg:  rgba(41, 38, 31, 0.04);
+    --ed-shadow:    0 24px 80px rgba(41, 30, 20, 0.18);
+
+    /* rgb triplets for rgba() composed in JS / inline gradients */
+    --ed-accent-rgb: 196, 90, 56;
+    --ed-bg-rgb:     244, 242, 236;
+    --ed-ink-rgb:    41, 38, 31;
+    --ed-hero-edge:  41, 38, 31;
+    --ed-hero-node:  110, 105, 95;
 
     /* type — display + body pairing */
     --ed-display: "Fraunces", "Iowan Old Style", "Source Serif Pro", Georgia, serif;
@@ -62,6 +77,36 @@
     --ed-content-max: 76rem;       /* matches existing max-w-7xl */
     --ed-prose-max:   38rem;       /* readable measure for body */
     --ed-gutter-x:    clamp(1rem, 4vw, 2.25rem);
+  }
+
+  /* Dark editorial — the site's original palette, opt-in via the
+     theme toggle (theme.js sets data-theme on <html> before paint). */
+  :root[data-theme="dark"] {
+    --ed-bg:        #0a1014;
+    --ed-bg-soft:   #0f161b;
+    --ed-surface:   #131c22;
+    --ed-hairline:  rgba(255, 255, 255, 0.06);
+    --ed-hairline-strong: rgba(255, 255, 255, 0.12);
+
+    --ed-ink:       #f3f5f7;
+    --ed-ink-soft:  #c7cfd5;
+    --ed-ink-dim:   #8b969e;
+    --ed-ink-mute:  #5a656d;
+
+    --ed-accent:        #4fb6dc;
+    --ed-accent-strong: #6cc7e9;
+    --ed-accent-mute:   rgba(79, 182, 220, 0.16);
+
+    --ed-topbar-bg: rgba(10, 16, 20, 0.78);
+    --ed-menu-bg:   rgba(10, 16, 20, 0.95);
+    --ed-field-bg:  rgba(255, 255, 255, 0.03);
+    --ed-shadow:    0 24px 80px rgba(0, 0, 0, 0.55);
+
+    --ed-accent-rgb: 79, 182, 220;
+    --ed-bg-rgb:     10, 16, 20;
+    --ed-ink-rgb:    243, 245, 247;
+    --ed-hero-edge:  255, 255, 255;
+    --ed-hero-node:  139, 150, 158;
   }
 
 /* ── editorial-base ── */
@@ -569,7 +614,7 @@
     position: sticky;
     top: 0;
     z-index: 50;
-    background: rgba(10, 16, 20, 0.78);
+    background: var(--ed-topbar-bg);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
     border-bottom: 1px solid var(--ed-hairline);
@@ -580,7 +625,7 @@
     padding: 1rem var(--ed-gutter-x);
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     gap: var(--ed-s-4);
   }
   .ed-topbar__brand {
@@ -608,6 +653,7 @@
     display: none;
     align-items: center;
     gap: var(--ed-s-5);
+    margin-inline-start: auto;     /* push the right cluster to the edge */
   }
   @media (min-width: 768px) {
     .ed-topbar__nav { display: flex; }
@@ -633,6 +679,28 @@
   @media (min-width: 768px) {
     .ed-topbar__menu { display: none; }
   }
+
+  /* Theme toggle — visible on every viewport. On mobile (nav hidden)
+     its auto margin pushes the control cluster to the right edge; on
+     desktop the nav's auto margin wins, so this just trails the links. */
+  .ed-topbar__theme {
+    display: inline-grid;
+    place-items: center;
+    width: 2.25rem; height: 2.25rem;
+    margin-inline-start: auto;
+    border-radius: 999px;
+    border: 1px solid var(--ed-hairline-strong);
+    color: var(--ed-ink-soft);
+    background: transparent;
+    cursor: pointer;
+    transition: color var(--ed-d-fast) var(--ed-ease-soft),
+                border-color var(--ed-d-fast) var(--ed-ease-soft);
+  }
+  .ed-topbar__theme:hover {
+    color: var(--ed-ink);
+    border-color: var(--ed-ink-soft);
+  }
+  .ed-topbar__theme .material-symbols-outlined { font-size: 1.25rem; }
 
 /* ── editorial-motion ── */
   /* Reusable reveal hook — JS adds .is-in when ScrollTrigger fires.
@@ -1139,7 +1207,7 @@
     background: var(--ed-bg-soft);
     border: 1px solid var(--ed-hairline-strong);
     border-radius: 1rem;
-    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+    box-shadow: var(--ed-shadow);
     text-align: left;
   }
   .ed-ai-modal__close {
@@ -1200,7 +1268,7 @@
     min-height: 8.5rem;
     resize: vertical;
     padding: 0.75rem 0.9rem;
-    background: rgba(255, 255, 255, 0.03);
+    background: var(--ed-field-bg);
     border: 1px solid var(--ed-hairline-strong);
     border-radius: 0.5rem;
     color: var(--ed-ink);
@@ -1250,3 +1318,44 @@
     color: var(--ed-ink-dim);
     font-size: var(--ed-fz-sm);
   }
+
+/* ── editorial-theme-bridges ── */
+  /* The few surfaces that predate the token system still carried
+     dark-only Tailwind utilities / SVG presentation attributes.
+     These rules route them through --ed-* so they flip with the theme.
+     (CSS properties beat SVG presentation attributes regardless of
+     specificity, and an ID/structural selector beats utility classes.) */
+
+  /* Mobile slide-in menu (Tailwind bg-background-dark/95 + text-white) */
+  #mobile-menu {
+    background-color: var(--ed-menu-bg);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+  #mobile-menu a,
+  #mobile-menu button { color: var(--ed-ink); }
+
+  /* experience.html chapter dividers (was border-white/5) */
+  .ed-divider { border-top: 1px solid var(--ed-hairline); }
+
+  /* experience.html tree-ring SVGs — authored with white paint */
+  .ed-rings [stroke="white"] { stroke: var(--ed-ink-soft); }
+  .ed-rings [fill="white"] { fill: var(--ed-ink-soft); }
+
+  /* index.html testimonial modal (still Tailwind primary/surface utilities) */
+  #testimonial-modal [data-testimonial-overlay] > div {
+    background: var(--ed-bg-soft);
+    border-color: var(--ed-hairline-strong);
+    box-shadow: var(--ed-shadow);
+  }
+  #modal-name { color: var(--ed-ink); }
+  #modal-text { color: var(--ed-ink-soft); }
+  #modal-role { color: var(--ed-accent-strong); }
+  #modal-image { border-color: var(--ed-accent-mute); }
+  #modal-initials {
+    background: var(--ed-accent-mute);
+    color: var(--ed-accent-strong);
+  }
+  #testimonial-modal [data-action="close-testimonial"] { color: var(--ed-ink-mute); }
+  #testimonial-modal [data-action="close-testimonial"]:hover { color: var(--ed-ink); }
+  #testimonial-modal .text-primary\/20 { color: var(--ed-accent); opacity: 0.28; }

--- a/assets/js/hero.js
+++ b/assets/js/hero.js
@@ -48,6 +48,22 @@
     var rafId = null;
     var lastTime = 0;
 
+    /* Canvas paint reads the active theme's colors from the CSS custom
+       properties (rgb triplets) so it flips with the light/dark toggle.
+       site.js fires 'themechange' on toggle; the rAF loop repaints with
+       the refreshed values on the next frame. */
+    function readPalette() {
+      var cs = getComputedStyle(document.documentElement);
+      function v(name, fb) { var x = cs.getPropertyValue(name).trim(); return x || fb; }
+      return {
+        edge:   v('--ed-hero-edge', '255, 255, 255'),
+        node:   v('--ed-hero-node', '139, 150, 158'),
+        accent: v('--ed-accent-rgb', '79, 182, 220')
+      };
+    }
+    var palette = readPalette();
+    window.addEventListener('themechange', function () { palette = readPalette(); });
+
     function sizeCanvas() {
       var rect = hero.getBoundingClientRect();
       width = rect.width;
@@ -265,11 +281,11 @@
         ctx.beginPath();
         ctx.moveTo(e.a.x, e.a.y);
         ctx.quadraticCurveTo(c.x, c.y, e.b.x, e.b.y);
-        ctx.strokeStyle = 'rgba(255, 255, 255, ' + (0.05 + e.glow * 0.05).toFixed(3) + ')';
+        ctx.strokeStyle = 'rgba(' + palette.edge + ', ' + (0.05 + e.glow * 0.05).toFixed(3) + ')';
         ctx.lineWidth = 1;
         ctx.stroke();
         if (e.glow > 0.02) {
-          ctx.strokeStyle = 'rgba(79, 182, 220, ' + (e.glow * 0.22).toFixed(3) + ')';
+          ctx.strokeStyle = 'rgba(' + palette.accent + ', ' + (e.glow * 0.22).toFixed(3) + ')';
           ctx.stroke();
         }
       });
@@ -280,23 +296,23 @@
         var pt = quadPoint(p.edge, c, clamp(p.t, 0, 1));
         ctx.beginPath();
         ctx.arc(pt.x, pt.y, 5, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(79, 182, 220, 0.18)';
+        ctx.fillStyle = 'rgba(' + palette.accent + ', 0.18)';
         ctx.fill();
         ctx.beginPath();
         ctx.arc(pt.x, pt.y, 1.6, 0, Math.PI * 2);
-        ctx.fillStyle = '#4fb6dc';
+        ctx.fillStyle = 'rgb(' + palette.accent + ')';
         ctx.fill();
       });
 
       nodes.forEach(function (n) {
         ctx.beginPath();
         ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(139, 150, 158, ' + (0.55 + n.flash * 0.4).toFixed(3) + ')';
+        ctx.fillStyle = 'rgba(' + palette.node + ', ' + (0.55 + n.flash * 0.4).toFixed(3) + ')';
         ctx.fill();
         if (n.label) {
           ctx.beginPath();
           ctx.arc(n.x, n.y, n.r + 3, 0, Math.PI * 2);
-          ctx.strokeStyle = 'rgba(79, 182, 220, 0.55)';
+          ctx.strokeStyle = 'rgba(' + palette.accent + ', 0.55)';
           ctx.lineWidth = 1;
           ctx.stroke();
         }
@@ -311,7 +327,7 @@
       ctx.font = '600 10px ui-monospace, "SF Mono", Menlo, monospace';
       ctx.letterSpacing = '0.12em';
       ctx.textBaseline = 'middle';
-      ctx.fillStyle = 'rgba(139, 150, 158, 0.9)';
+      ctx.fillStyle = 'rgba(' + palette.node + ', 0.9)';
       nodes.forEach(function (n) {
         if (!n.label) return;
         var w = ctx.measureText(n.label).width;

--- a/assets/js/rings.js
+++ b/assets/js/rings.js
@@ -21,6 +21,13 @@
   var SVG_NS = 'http://www.w3.org/2000/svg';
   var CENTER = '280 280';
 
+  /* Accent ping reads the active theme's accent from the CSS custom
+     property so it matches the light (clay) / dark (cyan) palette. */
+  function accentColor() {
+    var v = getComputedStyle(document.documentElement).getPropertyValue('--ed-accent').trim();
+    return v || '#4fb6dc';
+  }
+
   function initSvg(svg, index) {
     var group = svg.querySelector('g');
     if (!group) return;
@@ -156,7 +163,7 @@
     circle.setAttribute('cy', '280');
     circle.setAttribute('r', String(r));
     circle.setAttribute('fill', 'none');
-    circle.setAttribute('stroke', '#4fb6dc');
+    circle.setAttribute('stroke', accentColor());
     circle.setAttribute('stroke-width', '1');
     circle.setAttribute('opacity', '0.45');
     circle.setAttribute('aria-hidden', 'true');

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -77,6 +77,39 @@
     if (modal && modal.open) modal.close();
   }
 
+  /* Theme toggle. theme.js already applied the stored theme to <html>
+     before paint; here we sync the button face, flip + persist on click,
+     and broadcast a 'themechange' event so canvas/SVG painters re-read
+     their colors from the CSS custom properties. Light is the default. */
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+  }
+
+  function syncThemeButton() {
+    var dark = currentTheme() === 'dark';
+    var btns = document.querySelectorAll('[data-action="toggle-theme"]');
+    for (var i = 0; i < btns.length; i++) {
+      var icon = btns[i].querySelector('.material-symbols-outlined');
+      // Show the glyph for the theme the click switches TO.
+      if (icon) icon.textContent = dark ? 'light_mode' : 'dark_mode';
+      var label = dark ? 'Switch to light theme' : 'Switch to dark theme';
+      btns[i].setAttribute('aria-label', label);
+      btns[i].setAttribute('title', label);
+      btns[i].setAttribute('aria-pressed', dark ? 'true' : 'false');
+    }
+  }
+
+  function toggleTheme() {
+    var next = currentTheme() === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try { window.localStorage.setItem('theme', next); } catch (err) { /* storage blocked */ }
+    syncThemeButton();
+    track('theme_toggled', { theme: next });
+    window.dispatchEvent(new Event('themechange'));
+  }
+
+  syncThemeButton();
+
   document.addEventListener('click', function (event) {
     var target = event.target instanceof Element ? event.target : null;
     if (!target) return;
@@ -95,6 +128,7 @@
     if (actionEl) {
       switch (actionEl.getAttribute('data-action')) {
         case 'toggle-menu': toggleMenu(); break;
+        case 'toggle-theme': toggleTheme(); break;
         case 'open-testimonial': openTestimonial(actionEl); break;
         case 'close-testimonial': closeTestimonial(); break;
       }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,21 @@
+/*
+ * theme.js — applies the saved color theme to <html> before first paint.
+ *
+ * Loaded synchronously in <head> (it is a same-origin 'self' script, so it
+ * is allowed by the CSP that forbids inline scripts). Light is the default:
+ * with no stored choice the page renders the :root (light) palette, so no-JS
+ * and first-time visitors get light. A returning visitor who chose dark gets
+ * data-theme="dark" set here, before the body paints — no flash of light.
+ *
+ * The toggle button, icon sync, persistence, and the 'themechange' event all
+ * live in site.js (which runs after the DOM is ready).
+ */
+(function () {
+  'use strict';
+  var theme = 'light';
+  try {
+    var stored = window.localStorage.getItem('theme');
+    if (stored === 'dark' || stored === 'light') theme = stored;
+  } catch (err) { /* storage blocked — fall back to light */ }
+  document.documentElement.setAttribute('data-theme', theme);
+})();

--- a/certificates.html
+++ b/certificates.html
@@ -31,7 +31,7 @@
     <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260615" />
 
     <!-- Fonts: Fraunces (display) + Space Grotesk (body) + Material Symbols -->
     <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -41,7 +41,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
     <!-- Editorial design layer -->
-    <link rel="stylesheet" href="assets/css/editorial.css?v=20260611" />
+    <link rel="stylesheet" href="assets/css/editorial.css?v=20260615" />
 
     <style>
         .material-symbols-outlined {
@@ -50,10 +50,11 @@
 
         /* Scrollbar — editorial palette */
         ::-webkit-scrollbar { width: 8px; }
-        ::-webkit-scrollbar-track { background: #0a1014; }
-        ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-        ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+        ::-webkit-scrollbar-track { background: var(--ed-bg); }
+        ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
     </style>
+<script src="assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -75,6 +76,9 @@
                     Let&rsquo;s talk
                 </a>
             </nav>
+            <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+              <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+            </button>
             <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
                 <span class="material-symbols-outlined" aria-hidden="true">menu</span>
             </button>
@@ -352,8 +356,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
     <!-- Editorial motion (reveal hooks) -->
-    <script src="assets/js/site.js?v=20260611"></script>
-    <script src="assets/js/editorial.js?v=20260611"></script>
+    <script src="assets/js/site.js?v=20260615"></script>
+    <script src="assets/js/editorial.js?v=20260615"></script>
 </body>
 
 </html>

--- a/experience.html
+++ b/experience.html
@@ -31,8 +31,8 @@
     <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260611" />
-    <link rel="stylesheet" href="assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260615" />
+    <link rel="stylesheet" href="assets/css/editorial.css?v=20260615" />
 
     <!-- Fonts: Fraunces (display) + Space Grotesk (body) -->
     <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -51,16 +51,16 @@
         }
 
         ::-webkit-scrollbar-track {
-            background: #0a1014;
+            background: var(--ed-bg);
         }
 
         ::-webkit-scrollbar-thumb {
-            background: rgba(255, 255, 255, 0.08);
+            background: var(--ed-hairline-strong);
             border-radius: 4px;
         }
 
         ::-webkit-scrollbar-thumb:hover {
-            background: #4fb6dc;
+            background: var(--ed-accent);
         }
 
         .experience-role-title {
@@ -154,7 +154,7 @@
 
         .card-hover:hover {
             transform: translateY(-4px);
-            background-color: rgba(255, 255, 255, 0.08);
+            background-color: var(--ed-hairline-strong);
         }
 
         /* Reveal directional variants (additive to .reveal in editorial.css).
@@ -176,9 +176,10 @@
             transition-duration: 1100ms;
         }
     </style>
+<script src="assets/js/theme.js?v=20260615"></script>
 </head>
 
-<body class="ed-page font-display bg-background-dark text-white antialiased selection:bg-primary selection:text-white" data-motion-pending>
+<body class="ed-page" data-motion-pending>
     <div class="relative flex min-h-screen w-full flex-col">
 
         <!-- TopNavBar -->
@@ -199,6 +200,9 @@
                         Let&rsquo;s talk
                     </a>
                 </nav>
+                <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+                  <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+                </button>
                 <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
                     <span class="material-symbols-outlined" aria-hidden="true">menu</span>
                 </button>
@@ -253,7 +257,7 @@
             <div class="ed-career">
 
             <!-- ── Panel 1: Sema Technologies (9 rings accumulated) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-sema">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-sema">
                 <!-- Split layout — nav-aligned container -->
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 items-center gap-10 md:gap-14">
                     <!-- Left: 9 rings = current accumulated chapter -->
@@ -335,7 +339,7 @@
             </section>
 
             <!-- ── Panel 2: Labforward (8 rings accumulated) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-labforward">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-labforward">
                 <!-- Split layout — alternated: content left, SVG right on desktop -->
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 items-center gap-10 md:gap-14">
                     <!-- SVG: 8 rings — sits right on md+, first on mobile -->
@@ -396,7 +400,7 @@
             </section>
 
             <!-- ── Panel 3: LabTwin (7 rings accumulated) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-labtwin">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-labtwin">
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 items-center gap-10 md:gap-14">
                     <div class="flex items-center justify-center md:pr-6 reveal reveal-left">
                         <svg viewBox="0 0 560 560" xmlns="http://www.w3.org/2000/svg"
@@ -453,7 +457,7 @@
             </section>
 
             <!-- ── Panel 4: Thryve (5 rings accumulated) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-thryve">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-thryve">
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 items-center gap-10 md:gap-14">
                     <div class="flex items-center justify-center md:order-2 md:pl-6 reveal reveal-right">
                         <svg viewBox="0 0 560 560" xmlns="http://www.w3.org/2000/svg"
@@ -507,7 +511,7 @@
             </section>
 
             <!-- ── Panel 5: Ernst & Young (2 rings — start of career) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-ey">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-ey">
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 items-center gap-10 md:gap-14">
                     <div class="flex items-center justify-center md:pr-6 reveal reveal-left">
                         <svg viewBox="0 0 560 560" xmlns="http://www.w3.org/2000/svg"
@@ -556,7 +560,7 @@
             </div><!-- /.ed-career -->
 
             <!-- ── Panel 6: Skills & Education (editorial ledger) ── -->
-            <section class="w-full py-20 md:py-28 border-t border-white/5" id="role-skills">
+            <section class="w-full py-20 md:py-28 ed-divider" id="role-skills">
                 <div class="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div class="ed-howitworks__heading">
                         <div style="grid-column: 1 / -1;">
@@ -638,9 +642,9 @@
     <!-- GSAP scroll-driven motion (mirrors index.html) -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
-    <script src="assets/js/site.js?v=20260611"></script>
-    <script src="assets/js/editorial.js?v=20260611"></script>
-    <script src="assets/js/rings.js?v=20260611a"></script>
+    <script src="assets/js/site.js?v=20260615"></script>
+    <script src="assets/js/editorial.js?v=20260615"></script>
+    <script src="assets/js/rings.js?v=20260615"></script>
     <script src="assets/js/career.js?v=20260611b"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces (display) + Space Grotesk (body) -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -99,7 +99,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer (loaded after Tailwind so @layer takes precedence) -->
-  <link rel="stylesheet" href="assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/editorial.css?v=20260615" />
 
   <style>
     .material-symbols-outlined {
@@ -108,14 +108,15 @@
 
     /* Custom scrollbar — keep editorial palette */
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     /* Fix dialog display (kept from prior version for retained modals) */
     dialog:not([open]) { display: none; }
     dialog[open] { display: flex; }
   </style>
+<script src="assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -137,6 +138,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -434,14 +438,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion -->
-  <script src="assets/js/site.js?v=20260611"></script>
-  <script src="assets/js/editorial.js?v=20260611"></script>
+  <script src="assets/js/site.js?v=20260615"></script>
+  <script src="assets/js/editorial.js?v=20260615"></script>
 
   <!-- AI Match feature (kept) -->
   <script type="module" src="assets/js/ai-match.js?v=20260506a"></script>
 
   <!-- Living Workflow hero (canvas graph + intro choreography) -->
-  <script src="assets/js/hero.js?v=20260611c"></script>
+  <script src="assets/js/hero.js?v=20260615"></script>
 </body>
 
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -31,7 +31,7 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces (display) + Space Grotesk (body) + Material Symbols -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -41,7 +41,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer -->
-  <link rel="stylesheet" href="assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="assets/css/editorial.css?v=20260615" />
 
   <style>
     .material-symbols-outlined {
@@ -50,13 +50,14 @@
 
     /* Scrollbar — editorial palette */
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     dialog:not([open]) { display: none; }
     dialog[open] { display: flex; }
   </style>
+<script src="assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -78,6 +79,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -272,8 +276,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion (reveal hooks) -->
-  <script src="assets/js/site.js?v=20260611"></script>
-  <script src="assets/js/editorial.js?v=20260611"></script>
+  <script src="assets/js/site.js?v=20260615"></script>
+  <script src="assets/js/editorial.js?v=20260615"></script>
   <script src="assets/js/folio.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/achievement.html
+++ b/portfolio/achievement.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces display, Space Grotesk body, Material Symbols -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer -->
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -47,9 +47,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -83,7 +83,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -291,7 +291,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -300,9 +300,9 @@
       align-items: stretch;
       justify-content: center;
       background:
-        radial-gradient(circle at 28% 24%, rgba(108, 199, 233, 0.18), transparent 34%),
-        radial-gradient(circle at 78% 76%, rgba(108, 199, 233, 0.10), transparent 38%),
-        linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.01));
+        radial-gradient(circle at 28% 24%, rgba(var(--ed-accent-rgb), 0.18), transparent 34%),
+        radial-gradient(circle at 78% 76%, rgba(var(--ed-accent-rgb), 0.10), transparent 38%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.05), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--illustration img {
@@ -467,6 +467,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -488,6 +489,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -749,8 +753,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion -->
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/automation-tools.html
+++ b/portfolio/automation-tools.html
@@ -28,12 +28,12 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
   <link href="https://fonts.googleapis.com" rel="preconnect" />
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&family=Space+Grotesk:wght@300;400;500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -42,9 +42,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -78,7 +78,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -286,7 +286,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -295,14 +295,14 @@
       align-items: center;
       justify-content: center;
       background:
-        radial-gradient(circle at 35% 30%, rgba(108, 199, 233, 0.16), transparent 36%),
-        linear-gradient(135deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01));
+        radial-gradient(circle at 35% 30%, rgba(var(--ed-accent-rgb), 0.16), transparent 36%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.04), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--icon .material-symbols-outlined {
       font-size: clamp(5rem, 14vw, 11rem);
-      color: rgba(108, 199, 233, 0.58);
-      filter: drop-shadow(0 24px 80px rgba(79, 182, 220, 0.16));
+      color: rgba(var(--ed-accent-rgb), 0.58);
+      filter: drop-shadow(0 24px 80px rgba(var(--ed-accent-rgb), 0.16));
     }
 
 
@@ -433,6 +433,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -446,6 +447,9 @@
         <a class="ed-topbar__link" href="../certificates.html">Certifications</a>
         <a class="ed-btn ed-btn--accent" href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank" rel="noopener noreferrer" data-ga-event="external_link_clicked" data-ga-params='{"destination_platform":"linkedin","link_type":"cta_button","location":"nav_bar","page":"automation-tools"}'>Let&rsquo;s talk</a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu"><span class="material-symbols-outlined" aria-hidden="true">menu</span></button>
     </div>
   </header>
@@ -506,8 +510,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/interview-prep.html
+++ b/portfolio/interview-prep.html
@@ -28,12 +28,12 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
   <link href="https://fonts.googleapis.com" rel="preconnect" />
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&family=Space+Grotesk:wght@300;400;500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -42,9 +42,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -78,7 +78,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -286,7 +286,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -295,14 +295,14 @@
       align-items: center;
       justify-content: center;
       background:
-        radial-gradient(circle at 35% 30%, rgba(108, 199, 233, 0.16), transparent 36%),
-        linear-gradient(135deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01));
+        radial-gradient(circle at 35% 30%, rgba(var(--ed-accent-rgb), 0.16), transparent 36%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.04), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--icon .material-symbols-outlined {
       font-size: clamp(5rem, 14vw, 11rem);
-      color: rgba(108, 199, 233, 0.58);
-      filter: drop-shadow(0 24px 80px rgba(79, 182, 220, 0.16));
+      color: rgba(var(--ed-accent-rgb), 0.58);
+      filter: drop-shadow(0 24px 80px rgba(var(--ed-accent-rgb), 0.16));
     }
 
 
@@ -433,6 +433,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -446,6 +447,9 @@
         <a class="ed-topbar__link" href="../certificates.html">Certifications</a>
         <a class="ed-btn ed-btn--accent" href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank" rel="noopener noreferrer" data-ga-event="external_link_clicked" data-ga-params='{"destination_platform":"linkedin","link_type":"cta_button","location":"nav_bar","page":"interview-prep"}'>Let&rsquo;s talk</a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu"><span class="material-symbols-outlined" aria-hidden="true">menu</span></button>
     </div>
   </header>
@@ -506,8 +510,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/labforward.html
+++ b/portfolio/labforward.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/labforward-card.png" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces display, Space Grotesk body, Material Symbols -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer -->
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -47,9 +47,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -83,7 +83,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -291,7 +291,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -300,9 +300,9 @@
       align-items: stretch;
       justify-content: center;
       background:
-        radial-gradient(circle at 28% 24%, rgba(108, 199, 233, 0.18), transparent 34%),
-        radial-gradient(circle at 78% 76%, rgba(108, 199, 233, 0.10), transparent 38%),
-        linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.01));
+        radial-gradient(circle at 28% 24%, rgba(var(--ed-accent-rgb), 0.18), transparent 34%),
+        radial-gradient(circle at 78% 76%, rgba(var(--ed-accent-rgb), 0.10), transparent 38%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.05), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--illustration img {
@@ -445,6 +445,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -466,6 +467,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -716,8 +720,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion -->
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/labtwin.html
+++ b/portfolio/labtwin.html
@@ -28,7 +28,7 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/labtwin-card.png" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces display, Space Grotesk body, Material Symbols -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer -->
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -47,9 +47,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -83,7 +83,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -291,7 +291,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -300,9 +300,9 @@
       align-items: stretch;
       justify-content: center;
       background:
-        radial-gradient(circle at 28% 24%, rgba(108, 199, 233, 0.18), transparent 34%),
-        radial-gradient(circle at 78% 76%, rgba(108, 199, 233, 0.10), transparent 38%),
-        linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.01));
+        radial-gradient(circle at 28% 24%, rgba(var(--ed-accent-rgb), 0.18), transparent 34%),
+        radial-gradient(circle at 78% 76%, rgba(var(--ed-accent-rgb), 0.10), transparent 38%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.05), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--illustration img {
@@ -445,6 +445,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -466,6 +467,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -708,8 +712,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion -->
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/mcp-server.html
+++ b/portfolio/mcp-server.html
@@ -28,12 +28,12 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/MT.jpg" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
   <link href="https://fonts.googleapis.com" rel="preconnect" />
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&family=Space+Grotesk:wght@300;400;500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -42,9 +42,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -78,7 +78,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -286,7 +286,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -295,14 +295,14 @@
       align-items: center;
       justify-content: center;
       background:
-        radial-gradient(circle at 35% 30%, rgba(108, 199, 233, 0.16), transparent 36%),
-        linear-gradient(135deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01));
+        radial-gradient(circle at 35% 30%, rgba(var(--ed-accent-rgb), 0.16), transparent 36%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.04), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--icon .material-symbols-outlined {
       font-size: clamp(5rem, 14vw, 11rem);
-      color: rgba(108, 199, 233, 0.58);
-      filter: drop-shadow(0 24px 80px rgba(79, 182, 220, 0.16));
+      color: rgba(var(--ed-accent-rgb), 0.58);
+      filter: drop-shadow(0 24px 80px rgba(var(--ed-accent-rgb), 0.16));
     }
 
 
@@ -433,6 +433,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -446,6 +447,9 @@
         <a class="ed-topbar__link" href="../certificates.html">Certifications</a>
         <a class="ed-btn ed-btn--accent" href="https://www.linkedin.com/in/matthewthaokhamlue" target="_blank" rel="noopener noreferrer" data-ga-event="external_link_clicked" data-ga-params='{"destination_platform":"linkedin","link_type":"cta_button","location":"nav_bar","page":"mcp-server"}'>Let&rsquo;s talk</a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu"><span class="material-symbols-outlined" aria-hidden="true">menu</span></button>
     </div>
   </header>
@@ -524,8 +528,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 

--- a/portfolio/thryve.html
+++ b/portfolio/thryve.html
@@ -30,7 +30,7 @@
   <meta name="twitter:image" content="https://matthew-thaokhamlue.github.io/resume/images/thryve-card.png" />
 
   <!-- Tailwind CSS (precompiled; regenerate via tailwind.config.js) -->
-  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/tailwind.css?v=20260615" />
 
   <!-- Fonts: Fraunces display, Space Grotesk body, Material Symbols -->
   <link href="https://fonts.googleapis.com" rel="preconnect" />
@@ -40,7 +40,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
 
   <!-- Editorial design layer -->
-  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260611" />
+  <link rel="stylesheet" href="../assets/css/editorial.css?v=20260615" />
 
 
   <style>
@@ -49,9 +49,9 @@
     }
 
     ::-webkit-scrollbar { width: 8px; }
-    ::-webkit-scrollbar-track { background: #0a1014; }
-    ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 4px; }
-    ::-webkit-scrollbar-thumb:hover { background: #4fb6dc; }
+    ::-webkit-scrollbar-track { background: var(--ed-bg); }
+    ::-webkit-scrollbar-thumb { background: var(--ed-hairline-strong); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--ed-accent); }
 
     .case-backlink {
       display: inline-flex;
@@ -85,7 +85,7 @@
       width: min(42rem, 62vw);
       aspect-ratio: 1;
       border-radius: 50%;
-      background: radial-gradient(circle at 38% 38%, rgba(108, 199, 233, 0.18), rgba(79, 182, 220, 0.07) 42%, transparent 68%);
+      background: radial-gradient(circle at 38% 38%, rgba(var(--ed-accent-rgb), 0.18), rgba(var(--ed-accent-rgb), 0.07) 42%, transparent 68%);
       filter: blur(12px);
       pointer-events: none;
     }
@@ -293,7 +293,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, transparent 35%, rgba(10, 16, 20, 0.42));
+      background: linear-gradient(180deg, transparent 35%, rgba(var(--ed-bg-rgb), 0.42));
       pointer-events: none;
     }
 
@@ -302,9 +302,9 @@
       align-items: stretch;
       justify-content: center;
       background:
-        radial-gradient(circle at 28% 24%, rgba(108, 199, 233, 0.18), transparent 34%),
-        radial-gradient(circle at 78% 76%, rgba(108, 199, 233, 0.10), transparent 38%),
-        linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.01));
+        radial-gradient(circle at 28% 24%, rgba(var(--ed-accent-rgb), 0.18), transparent 34%),
+        radial-gradient(circle at 78% 76%, rgba(var(--ed-accent-rgb), 0.10), transparent 38%),
+        linear-gradient(135deg, rgba(var(--ed-ink-rgb), 0.05), rgba(var(--ed-ink-rgb), 0.01));
     }
 
     .case-feature__media--illustration img {
@@ -446,6 +446,7 @@
       .case-fact:last-child { border-bottom: 0; }
     }
   </style>
+<script src="../assets/js/theme.js?v=20260615"></script>
 </head>
 
 <body class="ed-page" data-motion-pending>
@@ -467,6 +468,9 @@
           Let&rsquo;s talk
         </a>
       </nav>
+      <button class="ed-topbar__theme" data-action="toggle-theme" aria-label="Switch to dark theme" title="Switch to dark theme" aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
       <button class="ed-topbar__menu" aria-label="Open menu" data-action="toggle-menu">
         <span class="material-symbols-outlined" aria-hidden="true">menu</span>
       </button>
@@ -721,8 +725,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d" crossorigin="anonymous"></script>
 
   <!-- Editorial motion -->
-  <script src="../assets/js/site.js?v=20260611"></script>
-  <script src="../assets/js/editorial.js?v=20260611"></script>
+  <script src="../assets/js/site.js?v=20260615"></script>
+  <script src="../assets/js/editorial.js?v=20260615"></script>
   <script src="../assets/js/case.js?v=20260611b"></script>
 </body>
 


### PR DESCRIPTION
## What & why

Adds a **light/dark theme toggle** and makes a warm **"Claude off-white" light theme the default**. The original dark editorial design is preserved as the opt-in dark mode.

## How it works

The `.ed-*` design system is ~95% driven by `--ed-*` CSS variables, so this is a token swap rather than a rewrite:

- **`editorial.css`** — `:root` now holds the light Claude palette (ivory `#f4f2ec` background, warm near-black ink `#29261f`, terracotta accent `#a8431f`); the original dark values moved to `:root[data-theme="dark"]`. Light is the default.
- **`assets/js/theme.js`** (new) — a synchronous same-origin `<head>` script (legal under the no-inline-script CSP) that applies the saved theme to `<html>` before first paint. Returning dark-mode users get dark with **no flash of light**.
- **Toggle button** (`data-action="toggle-theme"`) in the top bar of all 11 content pages. `site.js` flips the theme, persists to `localStorage`, swaps the sun/moon icon + aria, fires a GA `theme_toggled` event, and dispatches a `themechange` event.
- **Theme-aware paint** — `hero.js` (canvas workflow graph) and `rings.js` (tree rings) read accent/ink/node colors from CSS rgb-triplet tokens and re-read on `themechange`. The experience-page tree rings (authored `stroke="white"`) flip to warm gray via CSS attribute selectors with zero SVG edits.
- **Stragglers tokenized** — topbar/modal/field backgrounds, mobile menu, the testimonial modal (ID-scoped overrides that defeat its leftover `text-white`), experience dividers, scrollbars, and the 7 case-page hero glows (cyan → coral). The intentional white logo plate was left alone.

## Verification

- **All 33 contract tests pass** (`node --test tests/*.test.mjs`).
- Verified in-browser, light + dark: hero canvas repaints both ways · dark persists across reload with no flash · tree rings visible on cream · both modals readable (no white-on-cream text) · case pages, certificates, portfolio cards, and mobile menu all themed · accent-strong is 5.38:1 on ivory for body-size accent text.

## Notes

- No Tailwind regen needed (zero new utility classes). `about.html`/`cv.html` stay exempt. Shared `?v=` bumped to `20260615`.
- Per the request, light always wins on first visit; OS `prefers-color-scheme` is intentionally ignored until the user toggles.
- Merging to `main` triggers the GitHub Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
